### PR TITLE
eschweitzer78/update-2025-05-21-1030

### DIFF
--- a/sfGpsDs/main/default/lwc/sfGpsDsSocialSharing/sfGpsDsSocialSharing.js
+++ b/sfGpsDs/main/default/lwc/sfGpsDsSocialSharing/sfGpsDsSocialSharing.js
@@ -191,11 +191,13 @@ export default class extends LightningElement {
   }
 
   emit(name) {
-    this.dispatchEvent(new CustomEvent(name), {
-      detail: {
-        key: this.key,
-        url: this.url
-      }
-    });
+    this.dispatchEvent(
+      new CustomEvent(name, {
+        detail: {
+          key: this.key,
+          url: this.url
+        }
+      })
+    );
   }
 }

--- a/sfGpsDsAuNsw/main/default/lwc/forms/lwc/sfGpsDsAuNswFormAddressTypeaheadOsN/sfGpsDsAuNswFormAddressTypeaheadOsN.html
+++ b/sfGpsDsAuNsw/main/default/lwc/forms/lwc/sfGpsDsAuNswFormAddressTypeaheadOsN/sfGpsDsAuNswFormAddressTypeaheadOsN.html
@@ -107,11 +107,16 @@
           </div>
         </div>
 
-        <span lwc:if={mergedHelpText} id="helper" class="nsw-form__helper">
-          {mergedHelpText}
+        <span
+          lwc:if={computedShowHelpText}
+          id="helper"
+          class="nsw-form__helper"
+        >
+          <template lwc:if={isSmart}> {mergedHelpText} </template>
+          <template lwc:else> {mergedManualHelpText} </template>
         </span>
 
-        <div class="nsw-grid">
+        <div if:false={_propSetMap.manualAddressEditMode} class="nsw-grid">
           <div class="nsw-col nsw-col-12 street">
             <c-sf-gps-ds-au-nsw-input-os-n
               type="text"

--- a/sfGpsDsAuNsw/main/default/lwc/forms/lwc/sfGpsDsAuNswFormAddressTypeaheadOsN/sfGpsDsAuNswFormAddressTypeaheadOsN.js
+++ b/sfGpsDsAuNsw/main/default/lwc/forms/lwc/sfGpsDsAuNswFormAddressTypeaheadOsN/sfGpsDsAuNswFormAddressTypeaheadOsN.js
@@ -10,6 +10,8 @@ import SfGpsDsFormTypeaheadOsN from "c/sfGpsDsFormTypeaheadOsN";
 import SfGpsDsAuNswStatusHelperMixin from "c/sfGpsDsAuNswStatusHelperMixinOsN";
 import { debounce } from "omnistudio/utility";
 import { isArray } from "c/sfGpsDsHelpersOs";
+import { omniGetMergedField } from "c/sfGpsDsOmniHelpersOsN";
+
 import tmpl from "./sfGpsDsAuNswFormAddressTypeaheadOsN.html";
 
 const STATUS_TYPING = "typing";
@@ -22,6 +24,10 @@ const DEFAULT_COUNTRY = "Australia";
 
 const DEBUG = false;
 const CLASS_NAME = "sfGpsDsAuNswFormAddressTypeaheadOsN";
+
+const I18N = {
+  manualAddressHelpText: "Enter your address details below."
+};
 
 export default class extends SfGpsDsAuNswStatusHelperMixin(
   SfGpsDsFormTypeaheadOsN
@@ -113,10 +119,25 @@ export default class extends SfGpsDsAuNswStatusHelperMixin(
     return this.isSmart ? this.elementValueStatus === STATUS_RESOLVED : false;
   }
 
+  get computedShowHelpText() {
+    return this.mergedHelpText || !this.isSmart;
+  }
+
+  get mergedManualHelpText() {
+    return omniGetMergedField(
+      this,
+      this._propSetMap.manualAddressHelpText || I18N.manualAddressHelpText
+    );
+  }
+
   /* event management */
 
   handleToggle() {
     this.isSmart = !this.isSmart;
+
+    if (this._propSetMap.manualAddressEditMode) {
+      this.toggleEditMode(!this.isSmart);
+    }
 
     this.dispatchOmniEventUtil(
       this,

--- a/sfGpsDsAuVic2/main/default/lwc/sfGpsDsAuVic2Accordion/lwc/sfGpsDsAuVic2AccordionLwr/sfGpsDsAuVic2AccordionLwr.js
+++ b/sfGpsDsAuVic2/main/default/lwc/sfGpsDsAuVic2Accordion/lwc/sfGpsDsAuVic2AccordionLwr/sfGpsDsAuVic2AccordionLwr.js
@@ -21,6 +21,14 @@ const I18N = {
 /**
  * @slot Accordion-1
  * @slot Accordion-2
+ * @slot Accordion-3
+ * @slot Accordion-4
+ * @slot Accordion-5
+ * @slot Accordion-6
+ * @slot Accordion-7
+ * @slot Accordion-8
+ * @slot Accordion-9
+ * @slot Accordion-10
  */
 export default class SfGpsDsAuVic2Accordion extends ExpandableStateMixin(
   SfGpsDsLwc

--- a/sfGpsDsAuVic2/main/default/lwc/sfGpsDsAuVic2Accordion/lwc/sfGpsDsAuVic2AccordionLwr/sfGpsDsAuVic2AccordionLwr.js-meta.xml
+++ b/sfGpsDsAuVic2/main/default/lwc/sfGpsDsAuVic2Accordion/lwc/sfGpsDsAuVic2AccordionLwr/sfGpsDsAuVic2AccordionLwr.js-meta.xml
@@ -57,7 +57,7 @@
         type="String"
         label="Accordion 6 label"
         description="Accordion 6 label, leave empty to hide."
-        default="Accordion 2"
+        default="Accordion 6"
       />
       <property
         name="item7Title"


### PR DESCRIPTION
### What does this PR do?

Bug fixes + introducing a custom manual mode for the NSW typeahead as requested by NSW Building Commission

### What issues does this PR fix or reference?

- Issue in event emitted by sfGpsDsSocialShare
- Typo / issue in VIC2 LWR Accordion (only 2 slots) 

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[x] Code linting and formatting was performed.

### Functionality Before

The NSW address typeahead had a pre-canned, code-driven, manual address entry. 

### Functionality After

You can now request it to get into edit mode when "enter address manually is selected", hiding the original typeahead and showing whichever elements you have added to the typeahead. 

Use the JSON editor to add the following flags to a typeahead element:
- `manualAddressEditMode` set to `true` to indicate you'd like that new behaviour to apply
- `mergedManualHelpText` if you'd like to have a different help text when in manual mode (notwithstanding whether the former flag is set or not).
