### PR TITLE
NSW DS LWR Breadcrumbs typo bug

### DIFF
--- a/sfGpsDsAuNsw/main/default/lwc/sfGpsDsAuNswBreadcrumbs/lwc/sfGpsDsAuNswBreadcrumbsLwr/sfGpsDsAuNswBreadcrumbsLwr.html
+++ b/sfGpsDsAuNsw/main/default/lwc/sfGpsDsAuNswBreadcrumbs/lwc/sfGpsDsAuNswBreadcrumbsLwr/sfGpsDsAuNswBreadcrumbsLwr.html
@@ -8,7 +8,7 @@
   <c-sf-gps-ds-au-nsw-breadcrumbs
     lwc:else
     label={label}
-    items={_items}
+    items={_items.value}
     container-class-name={containerClassName}
     class-name={className}
   >


### PR DESCRIPTION
### What does this PR do?

fixes an issue with the NSW DS LWR Breadcrumbs when the content does not show up at all

## The PR fulfills these requirements:

[ ] Tests for the proposed changes have been added/updated.
[x] Code linting and formatting was performed.

