### PR TITLE
Add OmniStudio form overrides and Custom LWCs for Ontario Design System

### DIFF
--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormBlock/sfGpsDsCaOnFormBlock.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormBlock/sfGpsDsCaOnFormBlock.css
@@ -1,0 +1,31 @@
+/*
+ * Ontario Design System - Block (Accordion) Component Styles
+ */
+
+.sfgpsdscaon-block {
+  margin-bottom: 1.5rem;
+}
+
+.sfgpsdscaon-block__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+.ontario-accordion__toggle-icon {
+  width: 24px;
+  height: 24px;
+  margin-left: 0.5rem;
+  transition: transform 0.3s ease;
+}
+
+.ontario-accordion--open .ontario-accordion__toggle-icon {
+  transform: rotate(180deg);
+}
+
+.ontario-accordion__label {
+  font-weight: 600;
+  font-size: 1.125rem;
+  display: block;
+  padding: 0.75rem 0;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormBlock/sfGpsDsCaOnFormBlock.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormBlock/sfGpsDsCaOnFormBlock.html
@@ -1,0 +1,101 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System - Block (Accordion) for OmniStudio
+  
+  Uses accordion pattern for collapsible content sections.
+  
+  Compliance:
+  - LWR: Compatible (Light DOM pattern)
+  - LWS: Compatible (no restricted APIs)
+  - Ontario DS: Uses Ontario accordion styling
+  - WCAG 2.1 AA: 
+    - Proper ARIA expanded/controls
+    - Keyboard accessible
+    - Screen reader compatible
+-->
+<template>
+  <div class={computedClassName}>
+    <!-- Heading with toggle button -->
+    <div
+      class="ontario-accordion__title"
+      role="heading"
+      aria-level={blockHeadingLevel}
+    >
+      <template lwc:if={blockLabel}>
+        <!-- Collapsible button -->
+        <button
+          lwc:if={computedCollapsible}
+          type="button"
+          aria-expanded={expandContent}
+          aria-controls="content"
+          class={computedButtonClassName}
+          onclick={toggleContent}
+        >
+          {mergedLabel}
+          <svg
+            class="ontario-icon ontario-accordion__toggle-icon"
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
+          </svg>
+        </button>
+
+        <!-- Non-collapsible label -->
+        <span lwc:else class="ontario-accordion__label"> {mergedLabel} </span>
+      </template>
+    </div>
+
+    <!-- Repeat buttons -->
+    <template lwc:if={_propSetMap.repeat}>
+      <div class="sfgpsdscaon-block__actions">
+        <button
+          lwc:if={canRepeat}
+          type="button"
+          class="ontario-button ontario-button--secondary"
+          onclick={handleAdd}
+          aria-label={addAriaLabel}
+        >
+          Add
+        </button>
+        <button
+          lwc:if={canRemove}
+          type="button"
+          class="ontario-button ontario-button--secondary"
+          onclick={handleRemove}
+          aria-label={removeAriaLabel}
+        >
+          Remove
+        </button>
+      </div>
+    </template>
+
+    <!-- Validation error -->
+    <div
+      lwc:if={showValidationError}
+      class="ontario-error-messaging"
+      aria-live="assertive"
+      role="alert"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content">
+        {allCustomLabelsUtil.OmniBlockError}
+      </span>
+    </div>
+
+    <!-- Content -->
+    <div id="content" hidden={ariaHiddenValue} class={computedContentClassName}>
+      <slot></slot>
+    </div>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormBlock/sfGpsDsCaOnFormBlock.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormBlock/sfGpsDsCaOnFormBlock.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import SfGpsDsFormBlock from "c/sfGpsDsFormBlock";
+import tmpl from "./sfGpsDsCaOnFormBlock.html";
+
+/**
+ * @slot Block
+ * @description Ontario Design System Block (accordion) for OmniStudio forms.
+ * Uses Ontario accordion pattern for collapsible content sections.
+ *
+ * Compliance:
+ * - LWR: Uses Light DOM parent component
+ * - LWS: No eval(), proper namespace imports
+ * - Ontario DS: Uses accordion pattern from Ontario DS
+ * - WCAG 2.1 AA: Proper ARIA attributes for accordion pattern
+ */
+export default class SfGpsDsCaOnFormBlock extends SfGpsDsFormBlock {
+  /* computed */
+
+  get computedClassName() {
+    let classes = "ontario-accordion sfgpsdscaon-block";
+    if (this._propSetMap?.className) {
+      classes += ` ${this._propSetMap.className}`;
+    }
+    return classes;
+  }
+
+  get computedButtonClassName() {
+    let classes = "ontario-accordion__button";
+    if (this.expandContent) {
+      classes += " ontario-accordion--open";
+    }
+    return classes;
+  }
+
+  get computedContentClassName() {
+    let classes = "ontario-accordion__content";
+    if (this._propSetMap?.contentClassName) {
+      classes += ` ${this._propSetMap.contentClassName}`;
+    }
+    return classes;
+  }
+
+  get computedCollapsible() {
+    return !this._propSetMap?.nonCollapsible;
+  }
+
+  get computedIsH3Heading() {
+    return (this._propSetMap?.headingLevel || 3) === 3;
+  }
+
+  get showValidationError() {
+    return this.showValidation && this.allCustomLabelsUtil?.OmniBlockError;
+  }
+
+  get addAriaLabel() {
+    return `Add ${this.mergedLabel || "block"}`;
+  }
+
+  get removeAriaLabel() {
+    return `Remove ${this.mergedLabel || "block"}`;
+  }
+
+  /* methods */
+
+  toggleContent() {
+    this.expandContent = !this.expandContent;
+    this.ariaHiddenValue = !this.ariaHiddenValue;
+
+    if (this.expandContent) {
+      this.showValidation = false;
+    }
+  }
+
+  /* lifecycle */
+
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormBlock/sfGpsDsCaOnFormBlock.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormBlock/sfGpsDsCaOnFormBlock.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Block (accordion) for OmniStudio standard runtime forms. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCheckbox/sfGpsDsCaOnFormCheckbox.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCheckbox/sfGpsDsCaOnFormCheckbox.html
@@ -1,0 +1,73 @@
+<!-- sldsValidatorIgnore -->
+<template>
+  <div class="ontario-form-group">
+    <fieldset lwc:if={isCheckbox} class="ontario-fieldset">
+      <legend class="ontario-fieldset__legend">
+        <span class={computedLegendClassName}>
+          {label}
+          <span lwc:if={required} class="ontario-label__flag">(required)</span>
+          <span lwc:if={optional} class="ontario-label__flag">(optional)</span>
+        </span>
+        <slot name="label"> </slot>
+        <p lwc:if={fieldLevelHelp} id="helper" class="ontario-hint">
+          {fieldLevelHelp}
+        </p>
+
+        <div
+          lwc:if={sfGpsDsIsError}
+          class="ontario-error-messaging"
+          aria-live="assertive"
+          role="alert"
+          id="errorMessageBlock"
+        >
+          <svg
+            class="ontario-icon"
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+            />
+          </svg>
+          <span class="ontario-error-messaging__content"
+            >{sfGpsDsErrorMessage}</span
+          >
+        </div>
+      </legend>
+
+      <div class="ontario-checkboxes">
+        <template for:each={internalOpts} for:item="option" for:index="index">
+          <div class="ontario-checkboxes__item" key={option.id}>
+            <input
+              class="ontario-checkboxes__input"
+              type="checkbox"
+              required={required}
+              disabled={computedDisabledOrReadOnly}
+              id={option.id}
+              tabindex={tabIndex}
+              name={name}
+              aria-invalid={computedAriaInvalid}
+              aria-describedby={computedAriaDescribedBy}
+              checked={option.selected}
+              value={option.value}
+              data-index={index}
+              data-omni-input
+              onfocus={handleFocus}
+              onblur={handleBlur}
+              onchange={sfGpsDsOnChangeValue}
+              onkeydown={handleKeyDownEvent}
+            />
+            <label
+              class="ontario-checkboxes__label"
+              data-index={index}
+              for={option.id}
+            >
+              {option.label}
+            </label>
+          </div>
+        </template>
+      </div>
+    </fieldset>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCheckbox/sfGpsDsCaOnFormCheckbox.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCheckbox/sfGpsDsCaOnFormCheckbox.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { api } from "lwc";
+import OmnistudioCheckboxGroup from "c/sfGpsDsOmniCheckboxGroup";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormCheckbox.html";
+
+export default class SfGpsDsCaOnFormCheckbox extends OmnistudioCheckboxGroup {
+  @api readOnly;
+
+  /* computed */
+
+  get computedAriaDescribedBy() {
+    return computeClass({
+      helper: this.fieldLevelHelp,
+      errorMessageBlock: this.sfGpsDsIsError
+    });
+  }
+
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+
+  get computedLegendClassName() {
+    return {
+      "ontario-fieldset__legend": true,
+      "ontario-fieldset__legend--required": this.required
+    };
+  }
+
+  get computedDisabledOrReadOnly() {
+    return this.disabled || this.readOnly;
+  }
+
+  /* event handlers */
+
+  /**
+   * Handles blur events from checkbox elements.
+   * Triggers validation when focus leaves.
+   */
+  handleBlur() {
+    this.reportValidity();
+  }
+
+  /* lifecycle */
+
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCheckbox/sfGpsDsCaOnFormCheckbox.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCheckbox/sfGpsDsCaOnFormCheckbox.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCurrency/sfGpsDsCaOnFormCurrency.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCurrency/sfGpsDsCaOnFormCurrency.css
@@ -1,0 +1,85 @@
+.ontario-form-group {
+  margin-bottom: 1.5rem;
+}
+.ontario-label {
+  display: block;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+}
+.ontario-label__flag {
+  font-weight: 400;
+}
+.ontario-hint {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+.ontario-input__wrapper {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  max-width: 48rem;
+}
+.ontario-input__wrapper--prefix .ontario-input {
+  padding-left: 2.5rem;
+}
+.ontario-input__prefix {
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1rem;
+  color: #1a1a1a;
+  pointer-events: none;
+  z-index: 1;
+}
+.ontario-input {
+  display: block;
+  width: 100%;
+  padding: 0.625rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background-color: #fff;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+}
+.ontario-input--prefixed {
+  padding-left: 2.5rem;
+}
+.ontario-input:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 0;
+  box-shadow: 0 0 0 4px #009ade;
+}
+.ontario-input:disabled {
+  background-color: #e6e6e6;
+  border-color: #666;
+  color: #666;
+  cursor: not-allowed;
+}
+.ontario-input__error {
+  border-color: #cd0000;
+}
+.ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #cd0000;
+  margin-bottom: 0.5rem;
+}
+.ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  fill: #cd0000;
+}
+.ontario-error-messaging__content {
+  font-size: 1rem;
+  line-height: 1.5;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCurrency/sfGpsDsCaOnFormCurrency.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCurrency/sfGpsDsCaOnFormCurrency.html
@@ -1,0 +1,63 @@
+<!-- sldsValidatorIgnore -->
+<template>
+  <div class="ontario-form-group">
+    <label class="ontario-label" for={inputId}>
+      {mergedLabel}
+      <span lwc:if={showRequiredFlag} class="ontario-label__flag"
+        >(required)</span
+      >
+      <span lwc:if={showOptionalFlag} class="ontario-label__flag"
+        >(optional)</span
+      >
+    </label>
+
+    <p lwc:if={mergedHelpText} id={hintId} class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <div
+      lwc:if={sfGpsDsIsError}
+      id={errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <div class="ontario-input__wrapper ontario-input__wrapper--prefix">
+      <span class="ontario-input__prefix" aria-hidden="true">$</span>
+      <input
+        type="text"
+        inputmode="decimal"
+        id={inputId}
+        name={_name}
+        class={computedInputClassName}
+        value={elementValue}
+        placeholder={mergedPlaceholder}
+        disabled={_propSetMap.disabled}
+        readonly={_propSetMap.readOnly}
+        required={_propSetMap.required}
+        aria-required={computedAriaRequired}
+        aria-describedby={computedAriaDescribedBy}
+        aria-invalid={computedAriaInvalid}
+        data-omni-input
+        oninput={handleInput}
+        onchange={handleChange}
+        onblur={handleBlur}
+      />
+    </div>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCurrency/sfGpsDsCaOnFormCurrency.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCurrency/sfGpsDsCaOnFormCurrency.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import SfGpsDsFormCurrency from "c/sfGpsDsFormCurrency";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormCurrency.html";
+
+export default class SfGpsDsCaOnFormCurrency extends SfGpsDsFormCurrency {
+  _uniqueId = `currency-${Math.random().toString(36).substring(2, 11)}`;
+
+  get inputId() {
+    return `${this._uniqueId}-input`;
+  }
+  get hintId() {
+    return `${this._uniqueId}-hint`;
+  }
+  get errorId() {
+    return `${this._uniqueId}-error`;
+  }
+  get showRequiredFlag() {
+    return this._propSetMap?.required === true;
+  }
+  get showOptionalFlag() {
+    return this._propSetMap?.optional === true && !this._propSetMap?.required;
+  }
+  get computedInputClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "ontario-input--prefixed": true,
+      "ontario-input__error": this.sfGpsDsIsError
+    });
+  }
+  get computedAriaDescribedBy() {
+    return computeClass({
+      [this.hintId]: this.mergedHelpText,
+      [this.errorId]: this.sfGpsDsIsError
+    });
+  }
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+  get computedAriaRequired() {
+    return this._propSetMap?.required ? "true" : "false";
+  }
+
+  render() {
+    return tmpl;
+  }
+  connectedCallback() {
+    if (super.connectedCallback) super.connectedCallback();
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCurrency/sfGpsDsCaOnFormCurrency.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormCurrency/sfGpsDsCaOnFormCurrency.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Currency input for OmniStudio standard runtime forms. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDate/sfGpsDsCaOnFormDate.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDate/sfGpsDsCaOnFormDate.css
@@ -1,0 +1,92 @@
+.ontario-form-group {
+  margin-bottom: 1.5rem;
+}
+.ontario-fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  min-width: 0;
+}
+.ontario-fieldset__legend {
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+  padding: 0;
+}
+.ontario-label__flag {
+  font-weight: 400;
+}
+.ontario-label--small {
+  display: block;
+  font-weight: 400;
+  font-size: 0.875rem;
+  margin-bottom: 0.25rem;
+  color: #1a1a1a;
+}
+.ontario-hint {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+.ontario-date__group {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.ontario-date__group-input {
+  display: flex;
+  flex-direction: column;
+}
+.ontario-input {
+  padding: 0.625rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background-color: #fff;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+}
+.ontario-input--3-char-width {
+  width: 4rem;
+}
+.ontario-input--5-char-width {
+  width: 6rem;
+}
+.ontario-input:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 0;
+  box-shadow: 0 0 0 4px #009ade;
+}
+.ontario-input:disabled {
+  background-color: #e6e6e6;
+  border-color: #666;
+  color: #666;
+  cursor: not-allowed;
+}
+.ontario-input__error {
+  border-color: #cd0000;
+}
+.ontario-date--error .ontario-input {
+  border-color: #cd0000;
+}
+.ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #cd0000;
+  margin-bottom: 0.5rem;
+}
+.ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  fill: #cd0000;
+}
+.ontario-error-messaging__content {
+  font-size: 1rem;
+  line-height: 1.5;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDate/sfGpsDsCaOnFormDate.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDate/sfGpsDsCaOnFormDate.html
@@ -1,0 +1,114 @@
+<!-- sldsValidatorIgnore -->
+<template>
+  <div class="ontario-form-group">
+    <fieldset
+      class="ontario-fieldset"
+      aria-describedby={computedAriaDescribedBy}
+    >
+      <legend class="ontario-fieldset__legend">
+        {mergedLabel}
+        <span lwc:if={showRequiredFlag} class="ontario-label__flag"
+          >(required)</span
+        >
+        <span lwc:if={showOptionalFlag} class="ontario-label__flag"
+          >(optional)</span
+        >
+      </legend>
+
+      <p lwc:if={mergedHelpText} id={hintId} class="ontario-hint">
+        {mergedHelpText}
+      </p>
+
+      <div
+        lwc:if={hasError}
+        id={errorId}
+        class="ontario-error-messaging"
+        role="alert"
+        aria-live="assertive"
+      >
+        <svg
+          class="ontario-icon"
+          aria-hidden="true"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+          />
+        </svg>
+        <span class="ontario-error-messaging__content"
+          >{displayErrorMessage}</span
+        >
+      </div>
+
+      <div id={groupId} class={computedGroupClassName}>
+        <!-- Day Input -->
+        <div class="ontario-date__group-input">
+          <label for={dayId} class="ontario-label ontario-label--small"
+            >Day</label
+          >
+          <input
+            id={dayId}
+            type="text"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            class={computedDayMonthInputClassName}
+            value={_dayValue}
+            disabled={_propSetMap.disabled}
+            aria-required={computedAriaRequired}
+            aria-invalid={computedAriaInvalid}
+            aria-describedby={computedAriaDescribedBy}
+            data-omni-input
+            oninput={handleDayInput}
+            onblur={handleDateBlur}
+            onkeydown={handleKeydown}
+          />
+        </div>
+
+        <!-- Month Input -->
+        <div class="ontario-date__group-input">
+          <label for={monthId} class="ontario-label ontario-label--small"
+            >Month</label
+          >
+          <input
+            id={monthId}
+            type="text"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            class={computedDayMonthInputClassName}
+            value={_monthValue}
+            disabled={_propSetMap.disabled}
+            aria-required={computedAriaRequired}
+            aria-invalid={computedAriaInvalid}
+            aria-describedby={computedAriaDescribedBy}
+            oninput={handleMonthInput}
+            onblur={handleDateBlur}
+            onkeydown={handleKeydown}
+          />
+        </div>
+
+        <!-- Year Input -->
+        <div class="ontario-date__group-input">
+          <label for={yearId} class="ontario-label ontario-label--small"
+            >Year</label
+          >
+          <input
+            id={yearId}
+            type="text"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            class={computedYearInputClassName}
+            value={_yearValue}
+            disabled={_propSetMap.disabled}
+            aria-required={computedAriaRequired}
+            aria-invalid={computedAriaInvalid}
+            aria-describedby={computedAriaDescribedBy}
+            oninput={handleYearInput}
+            onblur={handleDateBlur}
+            onkeydown={handleKeydown}
+          />
+        </div>
+      </div>
+    </fieldset>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDate/sfGpsDsCaOnFormDate.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDate/sfGpsDsCaOnFormDate.js
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import SfGpsDsFormDate from "c/sfGpsDsFormDate";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormDate.html";
+
+export default class SfGpsDsCaOnFormDate extends SfGpsDsFormDate {
+  _uniqueId = `date-${Math.random().toString(36).substring(2, 11)}`;
+  _dayValue = "";
+  _monthValue = "";
+  _yearValue = "";
+  _validationMessage = "";
+  _isInvalid = false;
+
+  /* IDs */
+  get groupId() {
+    return `${this._uniqueId}-group`;
+  }
+  get dayId() {
+    return `${this._uniqueId}-day`;
+  }
+  get monthId() {
+    return `${this._uniqueId}-month`;
+  }
+  get yearId() {
+    return `${this._uniqueId}-year`;
+  }
+  get hintId() {
+    return `${this._uniqueId}-hint`;
+  }
+  get errorId() {
+    return `${this._uniqueId}-error`;
+  }
+
+  /* Computed properties */
+  get showRequiredFlag() {
+    return this._propSetMap?.required === true;
+  }
+  get showOptionalFlag() {
+    return this._propSetMap?.optional === true && !this._propSetMap?.required;
+  }
+  get computedAriaRequired() {
+    return this._propSetMap?.required ? "true" : "false";
+  }
+  get computedAriaInvalid() {
+    return this.hasError ? "true" : "false";
+  }
+
+  get computedAriaDescribedBy() {
+    return computeClass({
+      [this.hintId]: this.mergedHelpText,
+      [this.errorId]: this.hasError
+    });
+  }
+
+  get computedGroupClassName() {
+    return computeClass({
+      "ontario-date__group": true,
+      "ontario-date--error": this.hasError
+    });
+  }
+
+  get computedDayMonthInputClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "ontario-input--3-char-width": true,
+      "ontario-input__error": this.hasError
+    });
+  }
+
+  get computedYearInputClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "ontario-input--5-char-width": true,
+      "ontario-input__error": this.hasError
+    });
+  }
+
+  get hasError() {
+    return this.sfGpsDsIsError || this._isInvalid || !!this._validationMessage;
+  }
+
+  get displayErrorMessage() {
+    return this.sfGpsDsErrorMessage || this._validationMessage;
+  }
+
+  /* Parse value from elementValue */
+  _parseValue() {
+    const value = this.elementValue;
+    if (value && typeof value === "string") {
+      const parts = value.split("-");
+      if (parts.length === 3) {
+        this._yearValue = parts[0] || "";
+        this._monthValue = parts[1] ? String(parseInt(parts[1], 10)) : "";
+        this._dayValue = parts[2] ? String(parseInt(parts[2], 10)) : "";
+      }
+    }
+  }
+
+  _buildIsoDate() {
+    if (this._yearValue && this._monthValue && this._dayValue) {
+      const year = this._yearValue.padStart(4, "0");
+      const month = this._monthValue.padStart(2, "0");
+      const day = this._dayValue.padStart(2, "0");
+      return `${year}-${month}-${day}`;
+    }
+    return "";
+  }
+
+  _validateDate() {
+    this._validationMessage = "";
+    this._isInvalid = false;
+
+    const hasDay = !!this._dayValue;
+    const hasMonth = !!this._monthValue;
+    const hasYear = !!this._yearValue;
+    const hasAnyValue = hasDay || hasMonth || hasYear;
+
+    if (hasAnyValue && !(hasDay && hasMonth && hasYear)) {
+      this._validationMessage = "Please enter a complete date";
+      this._isInvalid = true;
+      return false;
+    }
+
+    if (!hasAnyValue) return true;
+
+    const day = parseInt(this._dayValue, 10);
+    if (isNaN(day) || day < 1 || day > 31) {
+      this._validationMessage = "Day must be between 1 and 31";
+      this._isInvalid = true;
+      return false;
+    }
+
+    const month = parseInt(this._monthValue, 10);
+    if (isNaN(month) || month < 1 || month > 12) {
+      this._validationMessage = "Month must be between 1 and 12";
+      this._isInvalid = true;
+      return false;
+    }
+
+    const year = parseInt(this._yearValue, 10);
+    if (isNaN(year) || year < 1000 || year > 9999) {
+      this._validationMessage = "Please enter a valid 4-digit year";
+      this._isInvalid = true;
+      return false;
+    }
+
+    const testDate = new Date(year, month - 1, day);
+    if (
+      testDate.getFullYear() !== year ||
+      testDate.getMonth() !== month - 1 ||
+      testDate.getDate() !== day
+    ) {
+      this._validationMessage = "Please enter a valid date";
+      this._isInvalid = true;
+      return false;
+    }
+
+    return true;
+  }
+
+  /* Event handlers */
+  handleDayInput(event) {
+    this._dayValue = event.target.value.replace(/\D/g, "").substring(0, 2);
+    event.target.value = this._dayValue;
+
+    if (this._dayValue.length === 2) {
+      const monthInput = this.template.querySelector(`#${this.monthId}`);
+      if (monthInput) monthInput.focus();
+    }
+  }
+
+  handleMonthInput(event) {
+    this._monthValue = event.target.value.replace(/\D/g, "").substring(0, 2);
+    event.target.value = this._monthValue;
+
+    if (this._monthValue.length === 2) {
+      const yearInput = this.template.querySelector(`#${this.yearId}`);
+      if (yearInput) yearInput.focus();
+    }
+  }
+
+  handleYearInput(event) {
+    this._yearValue = event.target.value.replace(/\D/g, "").substring(0, 4);
+    event.target.value = this._yearValue;
+  }
+
+  handleDateBlur() {
+    this._validateDate();
+    const isoDate = this._buildIsoDate();
+    if (isoDate || this._dayValue || this._monthValue || this._yearValue) {
+      this.applyCallResp(isoDate);
+    }
+    if (this.handleBlur) {
+      this.handleBlur({
+        target: this.template.querySelector(`#${this.dayId}`)
+      });
+    }
+  }
+
+  handleKeydown(event) {
+    if (event.key === "Backspace" && event.target.value === "") {
+      if (event.target.id === this.yearId) {
+        const monthInput = this.template.querySelector(`#${this.monthId}`);
+        if (monthInput) {
+          monthInput.focus();
+          event.preventDefault();
+        }
+      } else if (event.target.id === this.monthId) {
+        const dayInput = this.template.querySelector(`#${this.dayId}`);
+        if (dayInput) {
+          dayInput.focus();
+          event.preventDefault();
+        }
+      }
+    }
+  }
+
+  /* Lifecycle */
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (super.connectedCallback) super.connectedCallback();
+    this.classList.add("caon-scope");
+    this._parseValue();
+  }
+
+  renderedCallback() {
+    if (super.renderedCallback) super.renderedCallback();
+    // Re-parse value if it changed externally
+    if (
+      this.elementValue &&
+      !this._dayValue &&
+      !this._monthValue &&
+      !this._yearValue
+    ) {
+      this._parseValue();
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDate/sfGpsDsCaOnFormDate.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDate/sfGpsDsCaOnFormDate.js-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>true</isExposed>
+  <masterLabel>Ontario DS Form Date</masterLabel>
+  <description
+  >Ontario Design System Date Input for OmniStudio forms</description>
+  <targets>
+    <target>lightning__FlowScreen</target>
+  </targets>
+  <runtimeNamespace>omnistudio</runtimeNamespace>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDateTime/sfGpsDsCaOnFormDateTime.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDateTime/sfGpsDsCaOnFormDateTime.css
@@ -1,0 +1,11 @@
+/*
+ * Ontario Design System - DateTime Component Styles
+ */
+
+.sfgpsdscaon-datetime__input {
+  max-width: 280px;
+}
+
+.sfgpsdscaon-datetime__input::-webkit-calendar-picker-indicator {
+  cursor: pointer;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDateTime/sfGpsDsCaOnFormDateTime.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDateTime/sfGpsDsCaOnFormDateTime.html
@@ -1,0 +1,71 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System - DateTime Input for OmniStudio
+  
+  Combines date and time inputs with Ontario DS styling.
+  Uses HTML5 datetime-local input for simplicity.
+  
+  Compliance:
+  - LWR: Compatible (Light DOM pattern)
+  - LWS: Compatible (no restricted APIs)
+  - Ontario DS: Follows form field structure
+  - WCAG 2.1 AA: 
+    - Label associated with input group
+    - Hint text via aria-describedby
+    - Error messages with role="alert"
+    - Keyboard accessible
+-->
+<template>
+  <div class="ontario-form-group sfgpsdscaon-datetime">
+    <!-- Label -->
+    <label class="ontario-label" for={_inputId}>
+      {mergedLabel}
+      <span lwc:if={showFlag} class="ontario-label__flag">({flagText})</span>
+    </label>
+
+    <!-- Hint text -->
+    <p lwc:if={mergedHelpText} id={_hintId} class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <!-- Error message -->
+    <div
+      lwc:if={hasError}
+      id={_errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <!-- DateTime input using datetime-local -->
+    <input
+      type="datetime-local"
+      id={_inputId}
+      name={_name}
+      class={computedInputClassName}
+      value={elementValue}
+      disabled={_propSetMap.disabled}
+      readonly={_propSetMap.readOnly}
+      required={_propSetMap.required}
+      aria-describedby={computedAriaDescribedBy}
+      aria-invalid={hasError}
+      data-omni-input
+      onchange={handleChange}
+      onblur={handleBlur}
+    />
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDateTime/sfGpsDsCaOnFormDateTime.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDateTime/sfGpsDsCaOnFormDateTime.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import SfGpsDsFormDateTime from "c/sfGpsDsFormDateTime";
+import tmpl from "./sfGpsDsCaOnFormDateTime.html";
+
+/**
+ * @slot DateTime
+ * @description Ontario Design System DateTime input for OmniStudio forms.
+ * Combines date and time inputs with Ontario DS styling.
+ *
+ * Compliance:
+ * - LWR: Uses Light DOM parent component
+ * - LWS: No eval(), proper namespace imports
+ * - Ontario DS: Uses ontario date and input styling
+ * - WCAG 2.1 AA: Proper labeling, error messaging, keyboard support
+ */
+export default class SfGpsDsCaOnFormDateTime extends SfGpsDsFormDateTime {
+  /* computed */
+
+  get _inputId() {
+    return `datetime-${this._name}`;
+  }
+
+  get _dateId() {
+    return `date-${this._name}`;
+  }
+
+  get _timeId() {
+    return `time-${this._name}`;
+  }
+
+  get _hintId() {
+    return `hint-${this._name}`;
+  }
+
+  get _errorId() {
+    return `error-${this._name}`;
+  }
+
+  get hasError() {
+    return !!this.sfGpsDsErrorMessage;
+  }
+
+  get computedInputClassName() {
+    let classes = "ontario-input sfgpsdscaon-datetime__input";
+    if (this.hasError) {
+      classes += " ontario-input__error";
+    }
+    return classes;
+  }
+
+  get computedAriaDescribedBy() {
+    const ids = [];
+    if (this.mergedHelpText) ids.push(this._hintId);
+    if (this.hasError) ids.push(this._errorId);
+    return ids.length > 0 ? ids.join(" ") : null;
+  }
+
+  get showFlag() {
+    return this._propSetMap?.required || this._propSetMap?.optional;
+  }
+
+  get flagText() {
+    if (this._propSetMap?.required) return "required";
+    if (this._propSetMap?.optional) return "optional";
+    return "";
+  }
+
+  /* lifecycle */
+
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    this._readOnlyClass = "sfgpsdscaon-read-only";
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDateTime/sfGpsDsCaOnFormDateTime.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDateTime/sfGpsDsCaOnFormDateTime.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System DateTime input for OmniStudio standard runtime forms. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDischargePointSelector/sfGpsDsCaOnFormDischargePointSelector.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDischargePointSelector/sfGpsDsCaOnFormDischargePointSelector.css
@@ -1,0 +1,58 @@
+/**
+ * OmniStudio Discharge Point Selector Wrapper Styles
+ */
+
+.sfgpsdscaon-form-discharge-selector {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Selected coordinates display */
+.sfgpsdscaon-form-discharge-selector__selected {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  background-color: #f5f5f5;
+  border-left: 4px solid #0066cc;
+  margin-top: 0.5rem;
+}
+
+.sfgpsdscaon-form-discharge-selector__selected-content {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.sfgpsdscaon-form-discharge-selector__icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  color: #0066cc;
+  flex-shrink: 0;
+}
+
+.sfgpsdscaon-form-discharge-selector__text {
+  font-family: monospace;
+  font-size: 1rem;
+  color: #1a1a1a;
+}
+
+.sfgpsdscaon-form-discharge-selector__clear-btn {
+  background: none;
+  border: none;
+  color: #0066cc;
+  font-size: 1rem;
+  font-family: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
+.sfgpsdscaon-form-discharge-selector__clear-btn:hover {
+  color: #00478f;
+}
+
+.sfgpsdscaon-form-discharge-selector__clear-btn:focus {
+  box-shadow: 0 0 0 4px var(--ontario-colour-focus, #009adb);
+  outline: 4px solid transparent;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDischargePointSelector/sfGpsDsCaOnFormDischargePointSelector.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDischargePointSelector/sfGpsDsCaOnFormDischargePointSelector.html
@@ -1,0 +1,61 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  OmniStudio Discharge Point Selector Wrapper
+  
+  Integrates the Discharge Point Selector component into OmniScripts.
+-->
+<template>
+  <div class={computedContainerClassName}>
+    <!-- Label -->
+    <label lwc:if={label} class={computedLabelClassName}>
+      {label}
+      <span lwc:if={isRequired} class="ontario-label__flag">(required)</span>
+    </label>
+
+    <!-- Help Text -->
+    <p lwc:if={helpText} class="ontario-hint" id="discharge-selector-hint">
+      {helpText}
+    </p>
+
+    <!-- Selected Coordinates Display -->
+    <div
+      lwc:if={hasSelectedCoordinates}
+      class="sfgpsdscaon-form-discharge-selector__selected"
+    >
+      <div class="sfgpsdscaon-form-discharge-selector__selected-content">
+        <svg
+          class="ontario-icon sfgpsdscaon-form-discharge-selector__icon"
+          aria-hidden="true"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
+            fill="currentColor"
+          />
+        </svg>
+        <span class="sfgpsdscaon-form-discharge-selector__text"
+          >{selectedCoordinatesText}</span
+        >
+      </div>
+      <button
+        type="button"
+        class="sfgpsdscaon-form-discharge-selector__clear-btn"
+        onclick={handleClear}
+      >
+        Change
+      </button>
+    </div>
+
+    <!-- Discharge Point Selector -->
+    <c-sf-gps-ds-ca-on-discharge-point-selector
+      lwc:if={hasNoSelectedCoordinates}
+      button-label={buttonLabel}
+      modal-title={modalTitle}
+      vf-page-url={vfPageUrl}
+      default-latitude={defaultLatitude}
+      default-longitude={defaultLongitude}
+      oncontinue={handleContinue}
+    ></c-sf-gps-ds-ca-on-discharge-point-selector>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDischargePointSelector/sfGpsDsCaOnFormDischargePointSelector.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDischargePointSelector/sfGpsDsCaOnFormDischargePointSelector.js
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { api, LightningElement, track } from "lwc";
+import { OmniscriptBaseMixin } from "omnistudio/omniscriptBaseMixin";
+import { computeClass } from "c/sfGpsDsHelpers";
+import fetchVFDomainURL from "@salesforce/apex/sfGpsDsCaOnSiteSelectorCtr.fetchVFDomainURL";
+
+const DEBUG = false;
+const CLASS_NAME = "SfGpsDsCaOnFormDischargePointSelector";
+
+/**
+ * OmniStudio Discharge Point Selector Wrapper
+ *
+ * Integrates the Discharge Point Selector component into OmniScripts.
+ * Maps coordinate data to OmniScript fields.
+ *
+ * Compliance:
+ * - LWR/LWS: Compatible (uses same patterns as Site Selector)
+ * - OmniStudio: Extends OmniscriptBaseMixin
+ */
+export default class SfGpsDsCaOnFormDischargePointSelector extends OmniscriptBaseMixin(
+  LightningElement
+) {
+  /* ========================================
+   * PUBLIC @api PROPERTIES
+   * For Custom LWC elements, OmniStudio passes config via @api properties
+   * ======================================== */
+
+  /** @type {string} Field label - passed from OmniScript */
+  @api configLabel;
+
+  /** @type {string} Help text - passed from OmniScript */
+  @api configHelpText;
+
+  /** @type {boolean} Whether field is required - passed from OmniScript */
+  @api configRequired;
+
+  /** @type {string} Button label - passed from OmniScript */
+  @api configButtonLabel;
+
+  /** @type {string} Modal title - passed from OmniScript */
+  @api configModalTitle;
+
+  /** @type {number} Default latitude - passed from OmniScript */
+  @api configDefaultLatitude;
+
+  /** @type {number} Default longitude - passed from OmniScript */
+  @api configDefaultLongitude;
+
+  /** @type {string} VF page URL path - passed from OmniScript */
+  @api configVfPageUrl;
+
+  /* ========================================
+   * PRIVATE PROPERTIES
+   * ======================================== */
+
+  @track _vfPageUrl = "";
+  @track _coordinateData = null;
+
+  /* ========================================
+   * COMPUTED PROPERTIES - CONFIGURATION
+   * Checks @api props first, then jsonDef
+   * ======================================== */
+
+  get label() {
+    return (
+      this.configLabel || this._propSetMap?.label || "Discharge point location"
+    );
+  }
+
+  get helpText() {
+    return this.configHelpText || this._propSetMap?.helpText || "";
+  }
+
+  get isRequired() {
+    if (this.configRequired !== undefined) {
+      return Boolean(this.configRequired);
+    }
+    return Boolean(this._propSetMap?.required);
+  }
+
+  get buttonLabel() {
+    return (
+      this.configButtonLabel ||
+      this._customPropSetMap?.buttonLabel ||
+      this._propSetMap?.buttonLabel ||
+      "Add discharge point"
+    );
+  }
+
+  get modalTitle() {
+    return (
+      this.configModalTitle ||
+      this._customPropSetMap?.modalTitle ||
+      this._propSetMap?.modalTitle ||
+      "Source"
+    );
+  }
+
+  get defaultLatitude() {
+    return (
+      this.configDefaultLatitude ||
+      this._customPropSetMap?.defaultLatitude ||
+      this._propSetMap?.defaultLatitude ||
+      43.6532
+    );
+  }
+
+  get defaultLongitude() {
+    return (
+      this.configDefaultLongitude ||
+      this._customPropSetMap?.defaultLongitude ||
+      this._propSetMap?.defaultLongitude ||
+      -79.3832
+    );
+  }
+
+  get vfPageUrl() {
+    // If full URL is provided via @api, use it directly
+    if (this.configVfPageUrl) {
+      return this.configVfPageUrl;
+    }
+    // Otherwise use fetched or configured URL
+    return (
+      this._vfPageUrl ||
+      this._customPropSetMap?.vfPageUrl ||
+      this._propSetMap?.vfPageUrl ||
+      ""
+    );
+  }
+
+  /**
+   * Access standard OmniStudio properties from jsonDef.propSetMap
+   * @returns {Object}
+   */
+  get _propSetMap() {
+    return this.jsonDef?.propSetMap || {};
+  }
+
+  /**
+   * Access custom properties added via JSON Editor.
+   * OmniStudio nests custom propSetMap inside the standard propSetMap.
+   * Path: jsonDef.propSetMap.propSetMap.customProperty
+   * @returns {Object}
+   */
+  get _customPropSetMap() {
+    return this.jsonDef?.propSetMap?.propSetMap || {};
+  }
+
+  /* ========================================
+   * STATE COMPUTED PROPERTIES
+   * ======================================== */
+
+  get hasSelectedCoordinates() {
+    return this._coordinateData !== null;
+  }
+
+  get hasNoSelectedCoordinates() {
+    return this._coordinateData === null;
+  }
+
+  get selectedCoordinatesText() {
+    if (!this._coordinateData) return "";
+    const lat = this._coordinateData.latitude?.toFixed(6) || "";
+    const lng = this._coordinateData.longitude?.toFixed(6) || "";
+    return `${lat}, ${lng}`;
+  }
+
+  get computedLabelClassName() {
+    return computeClass({
+      "ontario-label": true,
+      "ontario-label--required": this.isRequired
+    });
+  }
+
+  get computedContainerClassName() {
+    return computeClass({
+      "sfgpsdscaon-form-discharge-selector": true,
+      "sfgpsdscaon-form-discharge-selector--has-value":
+        this.hasSelectedCoordinates
+    });
+  }
+
+  /* ========================================
+   * EVENT HANDLERS
+   * ======================================== */
+
+  handleContinue(event) {
+    const { coordinates } = event.detail;
+
+    if (DEBUG) console.log(CLASS_NAME, "handleContinue", coordinates);
+
+    this._coordinateData = coordinates;
+
+    // Set elementValue so OmniScript knows the field has a value
+    // OmniScript checks this property for required field validation
+    this.elementValue = `${coordinates.latitude}, ${coordinates.longitude}`;
+
+    // Update OmniScript data
+    this.omniUpdateDataJson({
+      latitude: coordinates.latitude,
+      longitude: coordinates.longitude,
+      utmZone: coordinates.utmZone || null,
+      utmEast: coordinates.utmEast || null,
+      utmNorth: coordinates.utmNorth || null
+    });
+
+    // Force OmniScript to re-validate and clear any cached validation state
+    // eslint-disable-next-line @lwc/lwc/no-async-operation
+    setTimeout(() => {
+      if (typeof this.omniValidate === "function") {
+        this.omniValidate(false);
+      }
+    }, 0);
+  }
+
+  handleClear(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this._coordinateData = null;
+
+    // Clear elementValue so OmniScript knows the field is empty
+    this.elementValue = null;
+
+    // Clear OmniScript data
+    this.omniUpdateDataJson({
+      latitude: null,
+      longitude: null,
+      utmZone: null,
+      utmEast: null,
+      utmNorth: null
+    });
+  }
+
+  /* ========================================
+   * LIFECYCLE
+   * ======================================== */
+
+  /**
+   * Component connected to DOM.
+   * Restores saved state from OmniScript JSON data.
+   */
+  connectedCallback() {
+    this.classList.add("caon-scope");
+    // Add data-omni-input to the HOST element so OmniScript can find and validate it
+    // This ensures OmniScript calls our @api checkValidity() directly
+    this.setAttribute("data-omni-input", "");
+    // Fetch VF domain URL (if not provided via @api)
+    if (!this.configVfPageUrl) {
+      this.loadVfDomainUrl();
+    }
+    // Restore saved state from OmniScript JSON
+    this.restoreSavedState();
+
+    if (DEBUG) console.log(CLASS_NAME, "connectedCallback", this._propSetMap);
+  }
+
+  /**
+   * Restores component state from OmniScript JSON data.
+   * Called on connectedCallback to handle "Previous" button navigation.
+   * @private
+   */
+  restoreSavedState() {
+    try {
+      // Get the saved data from OmniScript JSON using the element's path
+      const jsonPath = this.omniJsonDef?.JSONPath;
+      if (!jsonPath || !this.omniJsonData) return;
+
+      // Parse the JSON path to get the saved value
+      const pathParts = jsonPath.split(":");
+      let savedData = this.omniJsonData;
+
+      for (const part of pathParts) {
+        if (savedData && typeof savedData === "object") {
+          savedData = savedData[part];
+        } else {
+          savedData = null;
+          break;
+        }
+      }
+
+      // If we have saved data with coordinate fields, restore the component state
+      if (
+        savedData &&
+        (savedData.latitude != null || savedData.longitude != null)
+      ) {
+        this._coordinateData = {
+          latitude: savedData.latitude,
+          longitude: savedData.longitude,
+          utmZone: savedData.utmZone || null,
+          utmEast: savedData.utmEast || null,
+          utmNorth: savedData.utmNorth || null
+        };
+        // Restore elementValue so OmniScript knows the field has a value
+        this.elementValue = `${savedData.latitude}, ${savedData.longitude}`;
+
+        if (DEBUG)
+          console.log(CLASS_NAME, "restoreSavedState", this._coordinateData);
+      }
+    } catch (e) {
+      if (DEBUG) console.error(CLASS_NAME, "restoreSavedState error", e);
+      // Fail silently - state restoration is best-effort
+    }
+  }
+
+  async loadVfDomainUrl() {
+    try {
+      const domain = await fetchVFDomainURL();
+      if (domain) {
+        this._vfPageUrl = `${domain}/apex/sfGpsDsCaOnSiteSelectorPage`;
+      }
+    } catch (e) {
+      if (DEBUG) console.error(CLASS_NAME, "loadVfDomainUrl error", e);
+    }
+  }
+
+  /* ========================================
+   * VALIDATION METHODS - OmniScript Integration
+   * ======================================== */
+
+  /**
+   * Checks if the component is valid.
+   * Required for OmniScript "Next" button validation.
+   * @returns {boolean} True if valid (not required OR has value)
+   */
+  @api
+  checkValidity() {
+    // If not required, always valid
+    if (!this.isRequired) {
+      return true;
+    }
+    // If required, must have coordinate data
+    return (
+      this._coordinateData !== null &&
+      this._coordinateData.latitude != null &&
+      this._coordinateData.longitude != null
+    );
+  }
+
+  /**
+   * Reports validity and shows validation messages.
+   * Required for OmniScript step validation.
+   * @returns {boolean} True if valid
+   */
+  @api
+  reportValidity() {
+    const isValid = this.checkValidity();
+    this.showValidation = !isValid;
+    return isValid;
+  }
+
+  /**
+   * Sets a custom validity message.
+   * @param {string} message - Custom error message
+   */
+  @api
+  setCustomValidity(message) {
+    this._customValidityMessage = message;
+    this.showValidation = Boolean(message);
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDischargePointSelector/sfGpsDsCaOnFormDischargePointSelector.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDischargePointSelector/sfGpsDsCaOnFormDischargePointSelector.js-meta.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>true</isExposed>
+  <masterLabel>Ontario DS Form Discharge Point Selector</masterLabel>
+  <description
+  >OmniStudio wrapper for the Discharge Point Selector component with coordinate input.</description>
+  <targets>
+    <target>lightning__FlowScreen</target>
+    <target>lightningCommunity__Default</target>
+  </targets>
+  <targetConfigs>
+    <targetConfig targets="lightning__FlowScreen">
+      <property
+        name="configLabel"
+        type="String"
+        label="Label"
+        description="Field label"
+      />
+      <property
+        name="configHelpText"
+        type="String"
+        label="Help Text"
+        description="Help text below label"
+      />
+      <property
+        name="configRequired"
+        type="Boolean"
+        label="Required"
+        description="Whether field is required"
+        default="false"
+      />
+      <property
+        name="configButtonLabel"
+        type="String"
+        label="Button Label"
+        description="Button label to open selector"
+        default="Add discharge point"
+      />
+      <property
+        name="configModalTitle"
+        type="String"
+        label="Modal Title"
+        description="Title for modal dialog"
+        default="Source"
+      />
+      <property
+        name="configDefaultLatitude"
+        type="String"
+        label="Default Latitude"
+        description="Default map center latitude"
+        default="43.6532"
+      />
+      <property
+        name="configDefaultLongitude"
+        type="String"
+        label="Default Longitude"
+        description="Default map center longitude"
+        default="-79.3832"
+      />
+      <property
+        name="configVfPageUrl"
+        type="String"
+        label="VF Page URL"
+        description="Full URL to Visualforce page (optional - auto-fetched if blank)"
+      />
+    </targetConfig>
+    <targetConfig targets="lightningCommunity__Default">
+      <property
+        name="configLabel"
+        type="String"
+        label="Label"
+        description="Field label"
+      />
+      <property
+        name="configHelpText"
+        type="String"
+        label="Help Text"
+        description="Help text below label"
+      />
+      <property
+        name="configRequired"
+        type="Boolean"
+        label="Required"
+        description="Whether field is required"
+        default="false"
+      />
+      <property
+        name="configButtonLabel"
+        type="String"
+        label="Button Label"
+        description="Button label to open selector"
+        default="Add discharge point"
+      />
+      <property
+        name="configModalTitle"
+        type="String"
+        label="Modal Title"
+        description="Title for modal dialog"
+        default="Source"
+      />
+      <property
+        name="configDefaultLatitude"
+        type="String"
+        label="Default Latitude"
+        description="Default map center latitude"
+        default="43.6532"
+      />
+      <property
+        name="configDefaultLongitude"
+        type="String"
+        label="Default Longitude"
+        description="Default map center longitude"
+        default="-79.3832"
+      />
+      <property
+        name="configVfPageUrl"
+        type="String"
+        label="VF Page URL"
+        description="Full URL to Visualforce page (optional - auto-fetched if blank)"
+      />
+    </targetConfig>
+  </targetConfigs>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDisclosure/sfGpsDsCaOnFormDisclosure.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDisclosure/sfGpsDsCaOnFormDisclosure.css
@@ -1,0 +1,16 @@
+/*
+ * Ontario Design System - Disclosure Component Styles
+ */
+
+.sfgpsdscaon-disclosure__content {
+  margin-bottom: 1.5rem;
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 1rem;
+  background-color: var(--ontario-greyscale-5, #f2f2f2);
+  border-left: 4px solid var(--ontario-colour-black, #1a1a1a);
+}
+
+.sfgpsdscaon-disclosure__consent {
+  margin-top: 1rem;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDisclosure/sfGpsDsCaOnFormDisclosure.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDisclosure/sfGpsDsCaOnFormDisclosure.html
@@ -1,0 +1,82 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System - Disclosure Component for OmniStudio
+  
+  Displays disclosure content (rich text) with a required acceptance checkbox.
+  Used for terms and conditions, privacy policies, consent forms, etc.
+  
+  Compliance:
+  - LWR: Compatible (Light DOM pattern)
+  - LWS: Compatible (no restricted APIs)
+  - Ontario DS: Follows form field and checkbox patterns
+  - WCAG 2.1 AA: 
+    - Checkbox properly labeled
+    - Disclosure content linked via aria-describedby
+    - Error messages with role="alert"
+    - Keyboard accessible
+-->
+<template>
+  <div class="ontario-form-group sfgpsdscaon-disclosure">
+    <!-- Label -->
+    <label lwc:if={mergedLabel} class="ontario-label">
+      {mergedLabel}
+      <span lwc:if={_propSetMap.required} class="ontario-label__flag"
+        >(required)</span
+      >
+    </label>
+
+    <!-- Disclosure content -->
+    <div
+      id={_disclosureId}
+      class="ontario-callout sfgpsdscaon-disclosure__content"
+    >
+      <c-sf-gps-ds-osrt-omniscript-formatted-rich-text value={_dText}>
+      </c-sf-gps-ds-osrt-omniscript-formatted-rich-text>
+    </div>
+
+    <!-- Error message -->
+    <div
+      lwc:if={hasError}
+      id={_errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <!-- Consent checkbox -->
+    <div class="ontario-checkboxes sfgpsdscaon-disclosure__consent">
+      <div class="ontario-checkboxes__item">
+        <input
+          type="checkbox"
+          class={computedCheckboxClassName}
+          id={_checkboxId}
+          name={_name}
+          checked={elementValue}
+          disabled={_propSetMap.readOnly}
+          required={_propSetMap.required}
+          aria-describedby={computedAriaDescribedBy}
+          aria-invalid={hasError}
+          data-omni-input
+          onchange={handleChange}
+        />
+        <label class="ontario-checkboxes__label" for={_checkboxId}>
+          {mergedCheckLabel}
+        </label>
+      </div>
+    </div>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDisclosure/sfGpsDsCaOnFormDisclosure.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDisclosure/sfGpsDsCaOnFormDisclosure.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import SfGpsDsFormDisclosure from "c/sfGpsDsFormDisclosure";
+import tmpl from "./sfGpsDsCaOnFormDisclosure.html";
+
+/**
+ * @slot Disclosure
+ * @description Ontario Design System Disclosure component for OmniStudio forms.
+ * Displays disclosure content with a required acceptance checkbox.
+ * Used for terms and conditions, privacy policies, etc.
+ *
+ * Compliance:
+ * - LWR: Uses Light DOM pattern
+ * - LWS: No eval(), proper namespace imports
+ * - Ontario DS: Uses Ontario form styling and checkbox pattern
+ * - WCAG 2.1 AA: Proper labeling, error messaging, keyboard accessible
+ */
+export default class SfGpsDsCaOnFormDisclosure extends SfGpsDsFormDisclosure {
+  /* computed */
+
+  get _disclosureId() {
+    return `disclosure-${this._name}`;
+  }
+
+  get _checkboxId() {
+    return `checkbox-${this._name}`;
+  }
+
+  get _errorId() {
+    return `error-${this._name}`;
+  }
+
+  get hasError() {
+    return !!this.sfGpsDsErrorMessage;
+  }
+
+  get computedCheckboxClassName() {
+    let classes = "ontario-checkboxes__input";
+    if (this.hasError) {
+      classes += " ontario-input__error";
+    }
+    return classes;
+  }
+
+  get computedAriaDescribedBy() {
+    const ids = [];
+    ids.push(this._disclosureId);
+    if (this.hasError) {
+      ids.push(this._errorId);
+    }
+    return ids.join(" ");
+  }
+
+  /* lifecycle */
+
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    this._readOnlyClass = "sfgpsdscaon-read-only";
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDisclosure/sfGpsDsCaOnFormDisclosure.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormDisclosure/sfGpsDsCaOnFormDisclosure.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Disclosure component for OmniStudio standard runtime forms. Displays disclosure content with acceptance checkbox. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormEmail/sfGpsDsCaOnFormEmail.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormEmail/sfGpsDsCaOnFormEmail.css
@@ -1,0 +1,64 @@
+.ontario-form-group {
+  margin-bottom: 1.5rem;
+}
+.ontario-label {
+  display: block;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+}
+.ontario-label__flag {
+  font-weight: 400;
+}
+.ontario-hint {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+.ontario-input {
+  display: block;
+  width: 100%;
+  max-width: 48rem;
+  padding: 0.625rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background-color: #fff;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+}
+.ontario-input:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 0;
+  box-shadow: 0 0 0 4px #009ade;
+}
+.ontario-input:disabled {
+  background-color: #e6e6e6;
+  border-color: #666;
+  color: #666;
+  cursor: not-allowed;
+}
+.ontario-input__error {
+  border-color: #cd0000;
+}
+.ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #cd0000;
+  margin-bottom: 0.5rem;
+}
+.ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  fill: #cd0000;
+}
+.ontario-error-messaging__content {
+  font-size: 1rem;
+  line-height: 1.5;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormEmail/sfGpsDsCaOnFormEmail.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormEmail/sfGpsDsCaOnFormEmail.html
@@ -1,0 +1,60 @@
+<!-- sldsValidatorIgnore -->
+<template>
+  <div class="ontario-form-group">
+    <label class="ontario-label" for={inputId}>
+      {mergedLabel}
+      <span lwc:if={showRequiredFlag} class="ontario-label__flag"
+        >(required)</span
+      >
+      <span lwc:if={showOptionalFlag} class="ontario-label__flag"
+        >(optional)</span
+      >
+    </label>
+
+    <p lwc:if={mergedHelpText} id={hintId} class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <div
+      lwc:if={sfGpsDsIsError}
+      id={errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <input
+      type="email"
+      id={inputId}
+      name={_name}
+      class={computedInputClassName}
+      value={elementValue}
+      placeholder={mergedPlaceholder}
+      disabled={_propSetMap.disabled}
+      readonly={_propSetMap.readOnly}
+      required={_propSetMap.required}
+      aria-required={computedAriaRequired}
+      autocomplete={_autocomplete}
+      aria-describedby={computedAriaDescribedBy}
+      aria-invalid={computedAriaInvalid}
+      data-omni-input
+      oninput={handleInput}
+      onchange={handleChange}
+      onblur={handleBlur}
+    />
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormEmail/sfGpsDsCaOnFormEmail.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormEmail/sfGpsDsCaOnFormEmail.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import SfGpsDsFormEmail from "c/sfGpsDsFormEmail";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormEmail.html";
+
+export default class SfGpsDsCaOnFormEmail extends SfGpsDsFormEmail {
+  _uniqueId = `email-${Math.random().toString(36).substring(2, 11)}`;
+
+  get inputId() {
+    return `${this._uniqueId}-input`;
+  }
+  get hintId() {
+    return `${this._uniqueId}-hint`;
+  }
+  get errorId() {
+    return `${this._uniqueId}-error`;
+  }
+  get showRequiredFlag() {
+    return this._propSetMap?.required === true;
+  }
+  get showOptionalFlag() {
+    return this._propSetMap?.optional === true && !this._propSetMap?.required;
+  }
+  get computedInputClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "ontario-input__error": this.sfGpsDsIsError
+    });
+  }
+  get computedAriaDescribedBy() {
+    return computeClass({
+      [this.hintId]: this.mergedHelpText,
+      [this.errorId]: this.sfGpsDsIsError
+    });
+  }
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+  get computedAriaRequired() {
+    return this._propSetMap?.required ? "true" : "false";
+  }
+
+  render() {
+    return tmpl;
+  }
+  connectedCallback() {
+    if (super.connectedCallback) super.connectedCallback();
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormEmail/sfGpsDsCaOnFormEmail.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormEmail/sfGpsDsCaOnFormEmail.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Email input for OmniStudio standard runtime forms. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFile/sfGpsDsCaOnFormFile.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFile/sfGpsDsCaOnFormFile.css
@@ -1,0 +1,150 @@
+/*
+ * Ontario Design System - File Upload Component Styles
+ */
+
+.sfgpsdscaon-file {
+  margin-bottom: 1.5rem;
+}
+
+/* Override lightning-file-upload button styling */
+.sfgpsdscaon-file__upload-container {
+  /* Ontario button styling overrides for the upload button */
+  --lwc-spacingXxxSmall: 0.5rem;
+  --lwc-colorBorder: var(--ontario-colour-black, #1a1a1a);
+  --slds-c-button-neutral-color-background: var(
+    --ontario-colour-black,
+    #1a1a1a
+  );
+  --slds-c-button-neutral-color-background-hover: var(
+    --ontario-greyscale-60,
+    #333333
+  );
+  --slds-c-button-neutral-color-border: transparent;
+  --slds-c-button-neutral-color-border-hover: transparent;
+  --slds-c-button-text-color: var(--ontario-colour-white, #ffffff);
+  --slds-c-button-text-color-hover: var(--ontario-colour-white, #ffffff);
+  --slds-c-button-spacing-block-start: 0.75rem;
+  --slds-c-button-spacing-block-end: 0.75rem;
+  --slds-c-button-neutral-spacing-inline-start: 1.5rem;
+  --slds-c-button-neutral-spacing-inline-end: 1.5rem;
+  font-weight: 700;
+}
+
+.sfgpsdscaon-file__upload {
+  width: 100%;
+}
+
+/* File list styles */
+.sfgpsdscaon-file__list {
+  margin-top: 1rem;
+}
+
+.sfgpsdscaon-file__items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--ontario-greyscale-10, #e0e0e0);
+  border-radius: 4px;
+}
+
+.sfgpsdscaon-file__item {
+  border-bottom: 1px solid var(--ontario-greyscale-10, #e0e0e0);
+}
+
+.sfgpsdscaon-file__item:last-child {
+  border-bottom: none;
+}
+
+.sfgpsdscaon-file__item-content {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  gap: 0.75rem;
+}
+
+.sfgpsdscaon-file__item-icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  fill: var(--ontario-greyscale-40, #666666);
+}
+
+.sfgpsdscaon-file__item-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sfgpsdscaon-file__item-delete {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* WCAG 2.5.5: Touch target minimum 44x44px */
+  width: 2.75rem;
+  height: 2.75rem;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.sfgpsdscaon-file__item-delete:hover,
+.sfgpsdscaon-file__item-delete:focus {
+  background-color: var(--ontario-greyscale-5, #f5f5f5);
+}
+
+.sfgpsdscaon-file__item-delete:focus {
+  box-shadow: 0 0 0 4px var(--ontario-colour-focus, #009adb);
+  outline: 4px solid transparent;
+}
+
+.sfgpsdscaon-file__delete-icon {
+  width: 20px;
+  height: 20px;
+  fill: var(--ontario-colour-error, #cc0000);
+}
+
+/* Screen reader only */
+.ontario-show-for-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Loading indicator styles (inline) */
+.ontario-loading-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.ontario-loading-indicator--inline {
+  padding: 1rem 0;
+}
+.ontario-loading-indicator__spinner {
+  width: 2rem;
+  height: 2rem;
+  animation: spin 1.5s linear infinite;
+}
+.ontario-loading-indicator__spinner circle {
+  stroke: #1a1a1a;
+  stroke-dasharray: 125;
+  stroke-dashoffset: 100;
+  stroke-linecap: round;
+}
+@keyframes spin {
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFile/sfGpsDsCaOnFormFile.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFile/sfGpsDsCaOnFormFile.html
@@ -1,0 +1,150 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System - File Upload for OmniStudio
+  
+  Uses lightning-file-upload with Ontario DS styling overlay.
+  
+  Compliance:
+  - LWR: Uses lightning-file-upload (LWR compatible)
+  - LWS: Compatible (no restricted APIs)
+  - Ontario DS: Ontario form field structure
+  - WCAG 2.1 AA: 
+    - Proper labeling
+    - Error messages with role="alert"
+    - Keyboard accessible
+    - Screen reader announcements for upload status
+-->
+<template>
+  <!-- Loading indicator (inline) -->
+  <template lwc:if={isPageLoading}>
+    <div
+      class="ontario-loading-indicator ontario-loading-indicator--inline"
+      role="alert"
+      aria-live="assertive"
+      aria-busy="true"
+    >
+      <svg
+        class="ontario-loading-indicator__spinner"
+        viewBox="25 25 50 50"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <circle cx="50" cy="50" r="20" fill="none" stroke-width="4" />
+      </svg>
+      <p>Loading...</p>
+    </div>
+  </template>
+
+  <div class={_containerClasses} aria-labelledby="fileUploadLabel">
+    <div class="ontario-form-group sfgpsdscaon-file">
+      <!-- Label -->
+      <label id="fileUploadLabel" class={computedLabelClassName}>
+        {mergedLabel}
+        <span lwc:if={showFlag} class="ontario-label__flag">({flagText})</span>
+        <span lwc:if={_propSetMap.required} class="ontario-show-for-sr">
+          ({allCustomLabelsUtil.OmniRequired})
+        </span>
+      </label>
+
+      <!-- Hint text -->
+      <p lwc:if={mergedHelpText} id="helper" class="ontario-hint">
+        {mergedHelpText}
+      </p>
+
+      <!-- File upload component -->
+      <div class="sfgpsdscaon-file__upload-container">
+        <lightning-file-upload
+          class="sfgpsdscaon-file__upload"
+          label=" "
+          name={jsonDef.lwcId}
+          multiple
+          record-id={parentRecordId}
+          aria-invalid={_showValidation}
+          aria-describedby={computedAriaDescribedBy}
+          data-omni-input
+          onuploadfinished={handleUploadFinished}
+          onfocusout={handleFocusOut}
+        >
+        </lightning-file-upload>
+      </div>
+
+      <!-- Error message -->
+      <div
+        lwc:if={_showValidation}
+        class="ontario-error-messaging"
+        aria-live="assertive"
+        role="alert"
+        id="errorMessageBlock"
+      >
+        <svg
+          class="ontario-icon"
+          aria-hidden="true"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+          />
+        </svg>
+        <span class="ontario-error-messaging__content">{errorMessage}</span>
+      </div>
+    </div>
+
+    <!-- File list -->
+    <div lwc:if={hasFiles} class="sfgpsdscaon-file__list">
+      <!-- Screen reader status -->
+      <span id="upload-status" class="ontario-show-for-sr">
+        {ariaLiveStatusText}
+      </span>
+      <div aria-labelledby="upload-status" aria-live={ariaLiveStatus}></div>
+
+      <!-- File items -->
+      <ul class="sfgpsdscaon-file__items" role="list">
+        <template for:each={decoratedFiles} for:item="item">
+          <li key={item.key} class="sfgpsdscaon-file__item">
+            <div class="sfgpsdscaon-file__item-content">
+              <!-- File icon -->
+              <svg
+                class="sfgpsdscaon-file__item-icon"
+                aria-hidden="true"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                />
+              </svg>
+
+              <!-- File name -->
+              <span class="sfgpsdscaon-file__item-name" title={item.filename}>
+                {item.filename}
+              </span>
+
+              <!-- Delete button -->
+              <button
+                type="button"
+                class="sfgpsdscaon-file__item-delete"
+                title={item.deleteLabel}
+                aria-label={item.deleteLabel}
+                data-index={item.index}
+                data-id={item.data}
+                onclick={deleteFile}
+              >
+                <svg
+                  class="sfgpsdscaon-file__delete-icon"
+                  aria-hidden="true"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </li>
+        </template>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFile/sfGpsDsCaOnFormFile.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFile/sfGpsDsCaOnFormFile.js
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { track } from "lwc";
+import SfGpsDsFormFile from "c/sfGpsDsFormFile";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormFile.html";
+
+/**
+ * @slot File
+ * @description Ontario Design System File Upload for OmniStudio forms.
+ *
+ * This component wraps the lightning-file-upload component with Ontario DS
+ * styling for use in OmniStudio forms. Files are uploaded to Salesforce
+ * and linked to a parent record.
+ *
+ * ## Key Inherited Properties (from SfGpsDsFormFile)
+ * - `_value` {Array} - Array of uploaded file objects
+ * - `_recordId` {string} - Parent record ID for file association
+ * - `_isLoading` {boolean} - True during file upload
+ * - `_acceptedFormats` {Array} - Allowed file types
+ * - `_maxFiles` {number} - Maximum number of files allowed
+ * - `_showValidation` {boolean} - Whether to show validation state
+ *
+ * ## Key Inherited Methods (from SfGpsDsFormFile)
+ * - `handleUploadFinished(event)` - Handles successful file upload
+ * - `handleDelete(event)` - Handles file deletion
+ * - `reportValidity()` - Triggers validation check
+ *
+ * ## File Object Structure
+ * Each file in `_value` array has:
+ * ```javascript
+ * {
+ *   data: "068xxx...",        // ContentDocument ID
+ *   filename: "document.pdf", // Original filename
+ *   size: 12345,              // File size in bytes
+ *   type: "application/pdf"   // MIME type
+ * }
+ * ```
+ *
+ * ## Dependencies
+ * - Requires `lightning-file-upload` base component
+ * - Requires parent record ID for file storage
+ *
+ * ## Compliance
+ * - **LWR**: Uses lightning-file-upload (LWR compatible base component)
+ * - **LWS**: No eval(), proper namespace imports
+ * - **Ontario DS**: Ontario form field structure with custom upload styling
+ * - **WCAG 2.1 AA**: Proper labeling, keyboard accessible, screen reader support
+ *
+ * @example
+ * // Configured in OmniScript as "File" element type
+ * // Properties set in OmniScript Designer:
+ * // - accept: ".pdf,.doc,.docx"
+ * // - max: 5 (maximum files)
+ * // - required: true/false
+ *
+ * @see {@link https://developer.salesforce.com/docs/component-library/bundle/lightning-file-upload} lightning-file-upload docs
+ */
+export default class SfGpsDsCaOnFormFile extends SfGpsDsFormFile {
+  /**
+   * Computed aria-describedby value.
+   * Tracked to trigger re-render when helper elements change.
+   *
+   * @type {string}
+   * @track
+   */
+  @track computedAriaDescribedBy;
+
+  /* ========================================
+   * COMPUTED PROPERTIES - CSS CLASSES
+   * Used for Ontario DS styling in templates
+   * ======================================== */
+
+  /**
+   * Computes CSS classes for the label element.
+   * Adds required modifier when field is required.
+   *
+   * @returns {string} Space-separated CSS classes
+   * @template-binding: <label class={computedLabelClassName}>
+   */
+  get computedLabelClassName() {
+    return computeClass({
+      "ontario-label": true,
+      "ontario-label--required": this._propSetMap.required
+    });
+  }
+
+  /* ========================================
+   * COMPUTED PROPERTIES - DISPLAY STATE
+   * Control flag and file list rendering
+   * ======================================== */
+
+  /**
+   * Determines if required/optional flag should display.
+   *
+   * @returns {boolean} True if required or optional is set
+   * @template-binding: <span lwc:if={showFlag}>
+   */
+  get showFlag() {
+    return this._propSetMap?.required || this._propSetMap?.optional;
+  }
+
+  /**
+   * Returns the flag text ("required" or "optional").
+   *
+   * @returns {string} Flag text for display
+   * @template-binding: ({flagText})
+   */
+  get flagText() {
+    if (this._propSetMap?.required) return "required";
+    if (this._propSetMap?.optional) return "optional";
+    return "";
+  }
+
+  /**
+   * Determines if any files have been uploaded.
+   * Used to conditionally render the file list.
+   *
+   * @returns {boolean} True if _value array has items
+   * @template-binding: <div lwc:if={hasFiles} class="sfgpsdscaon-file__list">
+   */
+  get hasFiles() {
+    return this._value && this._value.length > 0;
+  }
+
+  /**
+   * Transforms uploaded files for template rendering.
+   * Adds unique key and index for list iteration.
+   *
+   * @returns {Array<Object>} Decorated file objects
+   * @template-binding: Used in file list iteration (for:each)
+   *
+   * @example
+   * // Returns:
+   * [
+   *   { data: "068xxx", filename: "doc.pdf", key: "068xxx", index: 0 },
+   *   { data: "068yyy", filename: "img.png", key: "068yyy", index: 1 }
+   * ]
+   */
+  get decoratedFiles() {
+    return (this._value || []).map((file, index) => ({
+      ...file,
+      key: file.data || index, // Use ContentDocument ID as key
+      index
+    }));
+  }
+
+  /* ========================================
+   * LIFECYCLE METHODS
+   * Component initialization and updates
+   * ======================================== */
+
+  /**
+   * Returns the Ontario DS template for this component.
+   *
+   * @returns {Object} The template to render
+   * @override
+   */
+  render() {
+    return tmpl;
+  }
+
+  /**
+   * Initializes component with Ontario DS scoping class.
+   *
+   * @override
+   */
+  connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    // CSS scoping class for Ontario DS styles
+    this.classList.add("caon-scope");
+  }
+
+  /**
+   * Computed aria-describedby initialization flag.
+   * @type {boolean}
+   * @private
+   */
+  _ariaDescribedByInitialized = false;
+
+  /**
+   * Updates aria-describedby after render.
+   * Collects IDs from all hint elements for screen reader association.
+   * Optimized: Only queries DOM once after initial render.
+   *
+   * @override
+   */
+  renderedCallback() {
+    if (super.renderedCallback) super.renderedCallback();
+
+    // Optimization: Only compute aria-describedby once
+    if (!this._ariaDescribedByInitialized) {
+      const helpers = this.template.querySelectorAll(".ontario-hint");
+      if (helpers.length > 0) {
+        this.computedAriaDescribedBy = [...helpers]
+          .map((item) => item.id)
+          .join(" ");
+        this._ariaDescribedByInitialized = true;
+      }
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFile/sfGpsDsCaOnFormFile.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFile/sfGpsDsCaOnFormFile.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System File Upload for OmniStudio standard runtime forms. Uses lightning-file-upload with Ontario styling. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFormula/sfGpsDsCaOnFormFormula.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFormula/sfGpsDsCaOnFormFormula.css
@@ -1,0 +1,15 @@
+/*
+ * Ontario Design System - Formula Component Styles
+ * 
+ * Read-only formula display styling aligned with Ontario DS.
+ */
+
+.sfgpsdscaon-formula-value {
+  background-color: var(--ontario-greyscale-5, #f2f2f2);
+  border: 1px solid var(--ontario-greyscale-20, #cccccc);
+  cursor: default;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  padding: 0.625rem 1rem;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFormula/sfGpsDsCaOnFormFormula.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFormula/sfGpsDsCaOnFormFormula.html
@@ -1,0 +1,29 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System - Formula Display for OmniStudio
+  
+  Read-only display of calculated/formula values.
+  Uses Ontario DS form group styling for consistency.
+  
+  Compliance:
+  - LWR: Compatible (uses Light DOM parent)
+  - LWS: Compatible (no restricted APIs)
+  - Ontario DS: Follows form field structure
+  - WCAG 2.1 AA: 
+    - Label associated with value
+    - Read-only content properly structured
+-->
+<template>
+  <div class="ontario-form-group">
+    <!-- Label -->
+    <label class="ontario-label"> {mergedLabel} </label>
+
+    <!-- Hint text -->
+    <p lwc:if={mergedHelpText} class="ontario-hint">{mergedHelpText}</p>
+
+    <!-- Formula value (read-only display) -->
+    <div class="ontario-input sfgpsdscaon-formula-value" data-omni-input>
+      {renderedValue}
+    </div>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFormula/sfGpsDsCaOnFormFormula.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFormula/sfGpsDsCaOnFormFormula.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import SfGpsDsFormFormula from "c/sfGpsDsFormFormula";
+import tmpl from "./sfGpsDsCaOnFormFormula.html";
+
+/**
+ * @slot Formula
+ * @description Ontario Design System Formula display for OmniStudio forms.
+ * Read-only display of calculated values.
+ * Extends the base form formula class with Ontario DS styling.
+ *
+ * Compliance:
+ * - LWR: Uses Light DOM parent component
+ * - LWS: No eval(), proper namespace imports
+ * - Ontario DS: Uses ontario form styling
+ * - WCAG 2.1 AA: Read-only, properly labeled
+ */
+export default class SfGpsDsCaOnFormFormula extends SfGpsDsFormFormula {
+  /* lifecycle */
+
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFormula/sfGpsDsCaOnFormFormula.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormFormula/sfGpsDsCaOnFormFormula.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Formula display for OmniStudio standard runtime forms. Read-only calculated value display. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormImage/sfGpsDsCaOnFormImage.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormImage/sfGpsDsCaOnFormImage.css
@@ -1,0 +1,157 @@
+/* Ontario Design System - Image Upload Styles */
+
+/* Upload container */
+.sfgpsdscaon-image__upload-container {
+  margin-top: 0.5rem;
+}
+
+.sfgpsdscaon-image__upload {
+  --slds-c-button-brand-color-background: var(
+    --ontario-colour-primary,
+    #1a1a1a
+  );
+  --slds-c-button-brand-color-background-hover: var(
+    --ontario-colour-grey-dark,
+    #4d4d4d
+  );
+}
+
+.sfgpsdscaon-image__disabled-message {
+  color: var(--ontario-colour-grey-dark, #4d4d4d);
+  font-style: italic;
+  margin: 0;
+}
+
+/* Small hint text */
+.ontario-hint--small {
+  font-size: 0.875rem;
+  color: var(--ontario-colour-grey-dark, #666);
+}
+
+/* Image preview grid */
+.sfgpsdscaon-image__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+/* Individual image item */
+.sfgpsdscaon-image__item {
+  border: 1px solid var(--ontario-colour-grey-light, #ccc);
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--ontario-colour-white, #fff);
+}
+
+/* Image preview container */
+.sfgpsdscaon-image__preview {
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ontario-colour-grey-lighter, #f5f5f5);
+  overflow: hidden;
+}
+
+/* Thumbnail image */
+.sfgpsdscaon-image__thumbnail {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Placeholder when no preview */
+.sfgpsdscaon-image__placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.sfgpsdscaon-image__placeholder-icon {
+  width: 48px;
+  height: 48px;
+  fill: var(--ontario-colour-grey, #999);
+}
+
+/* Image info section */
+.sfgpsdscaon-image__info {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem;
+  border-top: 1px solid var(--ontario-colour-grey-light, #ccc);
+}
+
+/* Filename */
+.sfgpsdscaon-image__filename {
+  font-size: 0.75rem;
+  color: var(--ontario-colour-grey-dark, #4d4d4d);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+/* Delete button */
+.sfgpsdscaon-image__delete {
+  flex-shrink: 0;
+  /* WCAG 2.5.5: Touch target minimum 44x44px */
+  width: 2.75rem;
+  height: 2.75rem;
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
+}
+
+.sfgpsdscaon-image__delete:hover {
+  background: var(--ontario-colour-grey-lighter, #f0f0f0);
+}
+
+.sfgpsdscaon-image__delete:focus {
+  outline: 4px solid var(--ontario-colour-focus, #009acd);
+  outline-offset: 0;
+}
+
+.sfgpsdscaon-image__delete-icon {
+  width: 20px;
+  height: 20px;
+  fill: var(--ontario-colour-error, #cd0000);
+}
+
+/* Loading indicator styles (inline) */
+.ontario-loading-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.ontario-loading-indicator--inline {
+  padding: 1rem 0;
+}
+.ontario-loading-indicator__spinner {
+  width: 2rem;
+  height: 2rem;
+  animation: spin 1.5s linear infinite;
+}
+.ontario-loading-indicator__spinner circle {
+  stroke: #1a1a1a;
+  stroke-dasharray: 125;
+  stroke-dashoffset: 100;
+  stroke-linecap: round;
+}
+@keyframes spin {
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormImage/sfGpsDsCaOnFormImage.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormImage/sfGpsDsCaOnFormImage.html
@@ -1,0 +1,176 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System - Image Upload for OmniStudio
+  
+  Extends file upload with image preview functionality.
+  
+  Compliance:
+  - LWR: Uses lightning-file-upload (LWR compatible)
+  - LWS: Compatible (no restricted APIs)
+  - Ontario DS: Ontario form field structure with image grid
+  - WCAG 2.1 AA: 
+    - Proper labeling
+    - Alt text for image previews
+    - Error messages with role="alert"
+    - Keyboard accessible
+    - Screen reader announcements
+-->
+<template>
+  <!-- Loading indicator (inline) -->
+  <template lwc:if={isPageLoading}>
+    <div
+      class="ontario-loading-indicator ontario-loading-indicator--inline"
+      role="alert"
+      aria-live="assertive"
+      aria-busy="true"
+    >
+      <svg
+        class="ontario-loading-indicator__spinner"
+        viewBox="25 25 50 50"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <circle cx="50" cy="50" r="20" fill="none" stroke-width="4" />
+      </svg>
+      <p>Loading...</p>
+    </div>
+  </template>
+
+  <div class={_containerClasses} aria-labelledby="imageUploadLabel">
+    <div class="ontario-form-group sfgpsdscaon-image">
+      <!-- Label -->
+      <label id="imageUploadLabel" class={computedLabelClassName}>
+        {mergedLabel}
+        <span lwc:if={showFlag} class="ontario-label__flag">({flagText})</span>
+        <span lwc:if={_propSetMap.required} class="ontario-show-for-sr">
+          ({allCustomLabelsUtil.OmniRequired})
+        </span>
+      </label>
+
+      <!-- Hint text -->
+      <p lwc:if={mergedHelpText} id="helper" class="ontario-hint">
+        {mergedHelpText}
+      </p>
+
+      <!-- Accepted formats hint -->
+      <p id="formats-hint" class="ontario-hint ontario-hint--small">
+        Accepted formats: JPG, PNG, GIF, WebP
+      </p>
+
+      <!-- Image upload component -->
+      <div class="sfgpsdscaon-image__upload-container">
+        <lightning-file-upload
+          lwc:if={isUploadEnabled}
+          class="sfgpsdscaon-image__upload"
+          label={uploadButtonLabel}
+          name={jsonDef.lwcId}
+          accept={acceptedFormats}
+          multiple={isMultiple}
+          record-id={parentRecordId}
+          aria-invalid={_showValidation}
+          aria-describedby={computedAriaDescribedBy}
+          data-omni-input
+          onuploadfinished={handleUploadFinished}
+          onfocusout={handleFocusOut}
+        >
+        </lightning-file-upload>
+
+        <!-- Message when upload is disabled (single mode with image) -->
+        <!-- WCAG 4.1.3: Status message announced to screen readers -->
+        <p
+          lwc:if={isUploadDisabled}
+          class="sfgpsdscaon-image__disabled-message"
+          role="status"
+          aria-live="polite"
+        >
+          Remove the current image to upload a new one.
+        </p>
+      </div>
+
+      <!-- Error message -->
+      <div
+        lwc:if={_showValidation}
+        class="ontario-error-messaging"
+        aria-live="assertive"
+        role="alert"
+        id="errorMessageBlock"
+      >
+        <svg
+          class="ontario-icon"
+          aria-hidden="true"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+          />
+        </svg>
+        <span class="ontario-error-messaging__content">{errorMessage}</span>
+      </div>
+    </div>
+
+    <!-- Image preview grid -->
+    <div lwc:if={hasImages} class="sfgpsdscaon-image__grid">
+      <!-- Screen reader status -->
+      <span class="ontario-show-for-sr" aria-live="polite">
+        {ariaLiveStatusText}
+      </span>
+
+      <!-- Image items -->
+      <template for:each={decoratedImages} for:item="item">
+        <div key={item.key} class="sfgpsdscaon-image__item">
+          <!-- Image preview -->
+          <div class="sfgpsdscaon-image__preview">
+            <img
+              lwc:if={item.previewUrl}
+              src={item.previewUrl}
+              alt={item.altText}
+              class="sfgpsdscaon-image__thumbnail"
+              loading="lazy"
+            />
+            <!-- Placeholder if no preview URL -->
+            <div lwc:else class="sfgpsdscaon-image__placeholder">
+              <svg
+                class="sfgpsdscaon-image__placeholder-icon"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"
+                />
+              </svg>
+            </div>
+          </div>
+
+          <!-- Image info and delete -->
+          <div class="sfgpsdscaon-image__info">
+            <span class="sfgpsdscaon-image__filename" title={item.filename}>
+              {item.filename}
+            </span>
+
+            <button
+              type="button"
+              class="sfgpsdscaon-image__delete"
+              title={item.deleteAriaLabel}
+              aria-label={item.deleteAriaLabel}
+              data-index={item.index}
+              data-id={item.data}
+              onclick={deleteFile}
+            >
+              <svg
+                class="sfgpsdscaon-image__delete-icon"
+                aria-hidden="true"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormImage/sfGpsDsCaOnFormImage.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormImage/sfGpsDsCaOnFormImage.js
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { track } from "lwc";
+import SfGpsDsFormFile from "c/sfGpsDsFormFile";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormImage.html";
+
+/**
+ * @slot Image
+ * @description Ontario Design System Image Upload for OmniStudio forms.
+ * Extends the base File upload with image-specific features and preview.
+ *
+ * This component overrides the standard OmniScript Image element to provide
+ * Ontario Design System styling with image preview functionality.
+ *
+ * ## Architecture
+ * - Extends: SfGpsDsFormFile (base file upload)
+ * - Accepts: Image file types only (.jpg, .jpeg, .png, .gif, .webp)
+ * - Features: Image thumbnail preview after upload
+ *
+ * ## Key Features
+ * - Image-only file type restriction
+ * - Thumbnail preview of uploaded images
+ * - Multiple image upload support
+ * - Delete functionality with preview update
+ *
+ * ## OmniScript Configuration
+ * In OmniScript Designer, configure the Image element:
+ * - Multiple: Allow multiple image uploads
+ * - Required: Make the field required
+ *
+ * ## OmniScript Registration
+ * Register in your OmniScript LWC override:
+ * ```javascript
+ * import sfGpsDsCaOnFormImage from "c/sfGpsDsCaOnFormImage";
+ *
+ * static elementTypeToLwcConstructorMap = {
+ *   ...OmniscriptBaseOsrt.elementTypeToLwcConstructorMap,
+ *   "Image": sfGpsDsCaOnFormImage,
+ * };
+ * ```
+ *
+ * Compliance:
+ * - LWR: Uses lightning-file-upload (LWR compatible)
+ * - LWS: No eval(), proper namespace imports
+ * - Ontario DS: Ontario form field structure with image preview grid
+ * - WCAG 2.1 AA: Alt text support, keyboard accessible, screen reader support
+ */
+export default class SfGpsDsCaOnFormImage extends SfGpsDsFormFile {
+  /**
+   * Accepted image file formats.
+   * @type {string}
+   */
+  _imageAccepts = ".jpg,.jpeg,.png,.gif,.webp";
+
+  /**
+   * Base URL for image preview.
+   * @type {string}
+   * @track
+   */
+  @track _baseUrl = "";
+
+  /**
+   * Computed aria-describedby value.
+   * @type {string}
+   * @track
+   */
+  @track computedAriaDescribedBy;
+
+  /* ========================================
+   * COMPUTED PROPERTIES - CSS CLASSES
+   * ======================================== */
+
+  /**
+   * Computes CSS classes for the label element.
+   * @returns {string} Space-separated CSS classes
+   */
+  get computedLabelClassName() {
+    return computeClass({
+      "ontario-label": true,
+      "ontario-label--required": this._propSetMap.required
+    });
+  }
+
+  /* ========================================
+   * COMPUTED PROPERTIES - DISPLAY STATE
+   * ======================================== */
+
+  /**
+   * Determines if required/optional flag should display.
+   * @returns {boolean} True if required or optional is set
+   */
+  get showFlag() {
+    return this._propSetMap?.required || this._propSetMap?.optional;
+  }
+
+  /**
+   * Returns the label for the upload button.
+   * AODA: Provides an accessible name for the file upload button.
+   * @returns {string} Upload button label
+   */
+  get uploadButtonLabel() {
+    return this.isMultiple
+      ? "Choose images to upload"
+      : "Choose an image to upload";
+  }
+
+  /**
+   * Returns the flag text ("required" or "optional").
+   * @returns {string} Flag text for display
+   */
+  get flagText() {
+    if (this._propSetMap?.required) return "required";
+    if (this._propSetMap?.optional) return "optional";
+    return "";
+  }
+
+  /**
+   * Determines if any images have been uploaded.
+   * @returns {boolean} True if _value array has items
+   */
+  get hasImages() {
+    return this._value && this._value.length > 0;
+  }
+
+  /**
+   * Determines if multiple images can be uploaded.
+   * @returns {boolean} True if multiple is enabled
+   */
+  get isMultiple() {
+    return this._propSetMap?.multiple === true;
+  }
+
+  /**
+   * Determines if more images can be added.
+   * For single-image mode, disabled after first upload.
+   * @returns {boolean} True if upload is disabled
+   */
+  get isUploadDisabled() {
+    if (this.isMultiple) return false;
+    return this._value && this._value.length > 0;
+  }
+
+  /**
+   * Determines if upload is enabled (inverse of disabled).
+   * Used in template since lwc:if doesn't support negation.
+   * @returns {boolean} True if upload is enabled
+   */
+  get isUploadEnabled() {
+    return !this.isUploadDisabled;
+  }
+
+  /**
+   * Returns the accepted file formats for images.
+   * @returns {string} Comma-separated list of extensions
+   */
+  get acceptedFormats() {
+    return this._imageAccepts;
+  }
+
+  /**
+   * Transforms uploaded images for template rendering.
+   * Includes preview URL for each image.
+   * @returns {Array<Object>} Decorated image objects
+   */
+  get decoratedImages() {
+    return (this._value || []).map((file, index) => {
+      // Files uploaded via OmniOut may have publicUrl
+      // Otherwise construct URL from vId (version ID)
+      let previewUrl = file.publicUrl;
+      if (!previewUrl && file.vId) {
+        previewUrl = `${this._baseUrl}sfc/servlet.shepherd/version/download/${file.vId}`;
+      }
+
+      return {
+        ...file,
+        key: file.data || index,
+        index,
+        previewUrl,
+        altText: file.filename || `Uploaded image ${index + 1}`,
+        deleteAriaLabel: `Remove ${file.filename || `image ${index + 1}`}`
+      };
+    });
+  }
+
+  /* ========================================
+   * LIFECYCLE METHODS
+   * ======================================== */
+
+  /**
+   * Returns the Ontario DS template for this component.
+   * @returns {Object} The template to render
+   */
+  render() {
+    return tmpl;
+  }
+
+  /**
+   * Initializes component with Ontario DS scoping and base URL.
+   */
+  connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    // CSS scoping class for Ontario DS styles
+    this.classList.add("caon-scope");
+
+    // Set base URL for image previews
+    this._initBaseUrl();
+  }
+
+  /**
+   * Computed aria-describedby initialization flag.
+   * @type {boolean}
+   * @private
+   */
+  _ariaDescribedByInitialized = false;
+
+  /**
+   * Updates aria-describedby after render.
+   * Optimized: Only queries DOM once after initial render.
+   */
+  renderedCallback() {
+    if (super.renderedCallback) super.renderedCallback();
+
+    // Optimization: Only compute aria-describedby once
+    if (!this._ariaDescribedByInitialized) {
+      const helpers = this.template.querySelectorAll(".ontario-hint");
+      if (helpers.length > 0) {
+        this.computedAriaDescribedBy = [...helpers]
+          .map((item) => item.id)
+          .join(" ");
+        this._ariaDescribedByInitialized = true;
+      }
+    }
+  }
+
+  /* ========================================
+   * PRIVATE METHODS
+   * ======================================== */
+
+  /**
+   * Initializes the base URL for image preview.
+   * Uses network path for community sites.
+   * LWS Note: window.location may be restricted - fallback to "/" if unavailable.
+   * @private
+   */
+  _initBaseUrl() {
+    try {
+      // LWS: window.location may be restricted in some security contexts
+      if (typeof window !== "undefined" && window.location) {
+        const networkPath = this.scriptHeaderDef?.networkUrlPathPrefix
+          ? `${this.scriptHeaderDef.networkUrlPathPrefix}/`
+          : "";
+        this._baseUrl = `${window.location.protocol}//${window.location.hostname}/${networkPath}`;
+      } else {
+        this._baseUrl = "/";
+      }
+    } catch {
+      // LWS may restrict window.location - fallback to root
+      this._baseUrl = "/";
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormImage/sfGpsDsCaOnFormImage.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormImage/sfGpsDsCaOnFormImage.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Image Upload for OmniStudio standard runtime forms. Includes image preview thumbnails. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormLookup/sfGpsDsCaOnFormLookup.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormLookup/sfGpsDsCaOnFormLookup.css
@@ -1,0 +1,145 @@
+/*
+ * Ontario Design System - Lookup Component Styles
+ */
+
+.sfgpsdscaon-lookup {
+  position: relative;
+}
+
+.sfgpsdscaon-combobox-container {
+  position: relative;
+}
+
+.sfgpsdscaon-combobox {
+  position: relative;
+}
+
+.sfgpsdscaon-combobox__form-element {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.sfgpsdscaon-combobox__input {
+  padding-right: 2.5rem;
+}
+
+.sfgpsdscaon-combobox__icon {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  pointer-events: none;
+  transition: transform 0.2s ease;
+}
+
+.sfgpsdscaon-is-open .sfgpsdscaon-combobox__icon {
+  transform: translateY(-50%) rotate(180deg);
+}
+
+.sfgpsdscaon-combobox__loader {
+  position: absolute;
+  right: 2.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+/* Dropdown styles */
+.sfgpsdscaon-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 7001;
+  max-height: 200px;
+  overflow-y: auto;
+  background: var(--ontario-colour-white, #ffffff);
+  border: 2px solid var(--ontario-colour-black, #1a1a1a);
+  border-top: none;
+  border-radius: 0 0 4px 4px;
+  display: none;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.sfgpsdscaon-dropdown--open {
+  display: block;
+}
+
+.sfgpsdscaon-listbox {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sfgpsdscaon-listbox__item {
+  margin: 0;
+  padding: 0;
+}
+
+.sfgpsdscaon-listbox__option {
+  display: block;
+  padding: 0.75rem 1rem;
+  text-decoration: none;
+  color: var(--ontario-colour-black, #1a1a1a);
+  cursor: pointer;
+  border-bottom: 1px solid var(--ontario-greyscale-10, #e0e0e0);
+}
+
+.sfgpsdscaon-listbox__option:last-child {
+  border-bottom: none;
+}
+
+.sfgpsdscaon-listbox__option:hover,
+.sfgpsdscaon-listbox__option.sfgpsdscaon-has-focus {
+  background-color: var(--ontario-colour-info-light, #e8f4fd);
+}
+
+.sfgpsdscaon-listbox__option[aria-selected="true"] {
+  background-color: var(--ontario-colour-link, #0066cc);
+  color: var(--ontario-colour-white, #ffffff);
+}
+
+.sfgpsdscaon-listbox__option--clear {
+  font-style: italic;
+  color: var(--ontario-greyscale-40, #666666);
+}
+
+/* Screen reader only */
+.ontario-show-for-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Loading indicator styles (inline) */
+.ontario-loading-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.ontario-loading-indicator--small .ontario-loading-indicator__spinner {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+.ontario-loading-indicator__spinner {
+  animation: spin 1.5s linear infinite;
+}
+.ontario-loading-indicator__spinner circle {
+  stroke: #1a1a1a;
+  stroke-dasharray: 125;
+  stroke-dashoffset: 100;
+  stroke-linecap: round;
+}
+@keyframes spin {
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormLookup/sfGpsDsCaOnFormLookup.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormLookup/sfGpsDsCaOnFormLookup.html
@@ -1,0 +1,189 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System - Lookup for OmniStudio
+  
+  Provides a searchable dropdown with autocomplete functionality.
+  
+  Compliance:
+  - LWR: Compatible (Light DOM pattern)
+  - LWS: Compatible (no restricted APIs)
+  - Ontario DS: Uses Ontario form field styling
+  - WCAG 2.1 AA: 
+    - Proper ARIA combobox pattern
+    - aria-expanded, aria-controls, aria-activedescendant
+    - Keyboard navigation (up/down arrows, enter, escape)
+    - Screen reader announcements
+-->
+<template>
+  <div class="ontario-form-group sfgpsdscaon-lookup">
+    <!-- Label -->
+    <div data-label="true">
+      <label
+        class={computedLabelClassName}
+        aria-label={mergedLabel}
+        for="lookupId"
+      >
+        {mergedLabel}
+        <span lwc:if={showFlag} class="ontario-label__flag">({flagText})</span>
+        <span lwc:if={_propSetMap.required} class="ontario-show-for-sr">
+          ({allCustomLabelsUtil.OmniRequired})
+        </span>
+      </label>
+    </div>
+
+    <!-- Hint text -->
+    <p lwc:if={mergedHelpText} id="helper" class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <!-- Screen reader announcements for results (AODA) -->
+    <div
+      class="ontario-show-for-sr"
+      aria-live="polite"
+      aria-atomic="true"
+      role="status"
+    >
+      <span lwc:if={show}>{resultsAnnouncement}</span>
+    </div>
+
+    <!-- Combobox container -->
+    <div class="sfgpsdscaon-combobox-container">
+      <div class="sfgpsdscaon-combobox">
+        <div class="sfgpsdscaon-combobox__form-element" role="none">
+          <!-- Input field -->
+          <!-- AODA: Added aria-required for screen reader announcement -->
+          <input
+            class={computedInputClassName}
+            type="text"
+            disabled={_propSetMap.readOnly}
+            required={_propSetMap.required}
+            aria-required={_propSetMap.required}
+            readonly={_propSetMap.readOnly}
+            aria-controls="lookup"
+            id="lookupId"
+            placeholder={mergedPlaceholder}
+            aria-invalid={sfGpsDsIsError}
+            aria-expanded={show}
+            aria-haspopup="listbox"
+            value={lookupDisplay}
+            aria-describedby={computedAriaDescribedBy}
+            role="combobox"
+            autocomplete="off"
+            data-omni-input
+            onblur={hideOptions}
+            onkeydown={handleKeyDown}
+            onkeyup={handleKeyUp}
+            onmouseup={showLookup}
+          />
+
+          <!-- Loading indicator (inline) -->
+          <template lwc:if={isPageLoading}>
+            <div class="sfgpsdscaon-combobox__loader">
+              <div
+                class="ontario-loading-indicator ontario-loading-indicator--small"
+                role="alert"
+                aria-live="assertive"
+                aria-busy="true"
+              >
+                <svg
+                  class="ontario-loading-indicator__spinner"
+                  viewBox="25 25 50 50"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <circle cx="50" cy="50" r="20" fill="none" stroke-width="4" />
+                </svg>
+              </div>
+            </div>
+          </template>
+
+          <!-- Dropdown arrow -->
+          <svg
+            class="sfgpsdscaon-combobox__icon"
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
+          </svg>
+        </div>
+
+        <!-- Dropdown list -->
+        <div
+          class={computedDropdownClassName}
+          id="lookup"
+          role="listbox"
+          onmousedown={handleKeyDown}
+          onmouseleave={handleKeyDown}
+          onmouseup={handleKeyDown}
+        >
+          <ul class="sfgpsdscaon-listbox" role="presentation">
+            <template
+              for:each={computedOptions}
+              for:item="optionItem"
+              for:index="optionIndex"
+            >
+              <li
+                key={optionItem.key}
+                class="sfgpsdscaon-listbox__item"
+                role="presentation"
+                data-option-index={optionIndex}
+                onmouseup={selectOption}
+                onmouseover={mouseOverFocus}
+              >
+                <div
+                  lwc:if={optionItem.isClear}
+                  class="sfgpsdscaon-listbox__option sfgpsdscaon-listbox__option--clear"
+                  id={optionItem.id}
+                  role="option"
+                  aria-selected={optionItem.selected}
+                >
+                  <span
+                    class="sfgpsdscaon-listbox__option-text"
+                    title={optionItem.value}
+                  >
+                    {optionItem.value}
+                  </span>
+                </div>
+
+                <a
+                  lwc:else
+                  href={optionItem.href}
+                  class="sfgpsdscaon-listbox__option"
+                  id={optionItem.id}
+                  role="option"
+                  aria-selected={optionItem.selected}
+                >
+                  {optionItem.value}
+                </a>
+              </li>
+            </template>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Error message -->
+    <div
+      lwc:if={sfGpsDsIsError}
+      class="ontario-error-messaging"
+      aria-live="assertive"
+      role="alert"
+      id="errorMessageBlock"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormLookup/sfGpsDsCaOnFormLookup.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormLookup/sfGpsDsCaOnFormLookup.js
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import SfGpsDsFormLookup from "c/sfGpsDsFormLookup";
+import { computeClass } from "c/sfGpsDsHelpers";
+import { Logger } from "c/sfGpsDsCaOnDebugUtils";
+import tmpl from "./sfGpsDsCaOnFormLookup.html";
+
+/**
+ * Logger instance for this component.
+ * Enable debug output by setting window.sfGpsDsCaOnDebug = true in console.
+ * @type {Logger}
+ */
+const log = new Logger("SfGpsDsCaOnFormLookup");
+
+/**
+ * Internationalization strings for the Lookup component.
+ * @type {Object}
+ */
+const I18N = {
+  clearLabel: "-- Clear --"
+};
+
+/**
+ * CSS class applied when dropdown is open.
+ * @type {string}
+ */
+const THEME_IS_OPEN_CLASSNAME = "sfgpsdscaon-is-open";
+
+/**
+ * CSS class applied to the currently focused option.
+ * @type {string}
+ */
+const THEME_HAS_FOCUS_CLASSNAME = "sfgpsdscaon-has-focus";
+
+/**
+ * @slot Lookup
+ * @description Ontario Design System Lookup for OmniStudio forms.
+ *
+ * Lookup provides a searchable dropdown with autocomplete functionality.
+ * It fetches options from a DataRaptor or Integration Procedure and allows
+ * users to search and select from the results.
+ *
+ * ## Key Inherited Properties (from SfGpsDsFormLookup)
+ * - `options` {Array} - Available options to display
+ * - `show` {boolean} - Whether dropdown is visible
+ * - `selectedIndex` {number} - Currently selected option index
+ * - `highlightIndex` {number} - Currently highlighted option index
+ * - `_inputRef` {HTMLElement} - Reference to the input element
+ *
+ * ## Key Inherited Methods (from SfGpsDsFormLookup)
+ * - `showOptions()` - Opens the dropdown
+ * - `hideOptions()` - Closes the dropdown
+ * - `selectOption(event)` - Handles option selection
+ * - `ariaFocus(index)` - Manages ARIA focus for accessibility
+ *
+ * ## ARIA Combobox Pattern
+ * This component implements the WAI-ARIA combobox pattern:
+ * - Input has role="combobox" with aria-expanded
+ * - Listbox has role="listbox"
+ * - Options have role="option" with aria-selected
+ * - Active descendant tracked via aria-activedescendant
+ *
+ * ## Compliance
+ * - **LWR**: Uses Light DOM parent component
+ * - **LWS**: No eval(), proper namespace imports
+ * - **Ontario DS**: Uses Ontario form field styling
+ * - **WCAG 2.1 AA**: Full keyboard navigation, screen reader support
+ *
+ * @example
+ * // Configured in OmniScript as "Lookup" element type
+ * // Requires DataRaptor or Integration Procedure for options
+ *
+ * @see {@link sfGpsDsCaOnFormTypeahead} Similar component for typeahead
+ * @see {@link sfGpsDsCaOnFormSelect} Simpler dropdown without search
+ */
+export default class SfGpsDsCaOnFormLookup extends SfGpsDsFormLookup {
+  /* ========================================
+   * COMPUTED PROPERTIES - CSS CLASSES
+   * Used for Ontario DS styling in templates
+   * ======================================== */
+
+  /**
+   * Computes CSS classes for the label element.
+   * Adds required modifier when field is required.
+   *
+   * @returns {string} Space-separated CSS classes
+   * @template-binding: <label class={computedLabelClassName}>
+   */
+  get computedLabelClassName() {
+    return computeClass({
+      "ontario-label": true,
+      "ontario-label--required": this._propSetMap.required
+    });
+  }
+
+  /**
+   * Computes CSS classes for the input element.
+   * Adds error styling when validation fails.
+   *
+   * @returns {string} Space-separated CSS classes
+   * @template-binding: <input class={computedInputClassName}>
+   */
+  get computedInputClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "sfgpsdscaon-combobox__input": true,
+      "ontario-input__error": this.sfGpsDsIsError
+    });
+  }
+
+  /**
+   * Computes aria-describedby attribute for accessibility.
+   * Links input to helper text and error message elements.
+   *
+   * @returns {string|null} Space-separated IDs or null
+   * @template-binding: aria-describedby={computedAriaDescribedBy}
+   */
+  /**
+   * Computes aria-describedby attribute for accessibility.
+   * Links input to helper text and error message elements.
+   *
+   * @returns {string|null} Space-separated IDs or null
+   * @template-binding: aria-describedby={computedAriaDescribedBy}
+   */
+  get computedAriaDescribedBy() {
+    const ids = [];
+    if (this.mergedHelpText) ids.push("helper");
+    if (this.sfGpsDsIsError) ids.push("errorMessageBlock");
+    return ids.length > 0 ? ids.join(" ") : null;
+  }
+
+  /**
+   * Computes CSS classes for the dropdown container.
+   * Controls visibility via open modifier.
+   *
+   * @returns {string} Space-separated CSS classes
+   * @template-binding: <div class={computedDropdownClassName}>
+   */
+  get computedDropdownClassName() {
+    return computeClass({
+      "sfgpsdscaon-dropdown": true,
+      "sfgpsdscaon-dropdown--open": this.show
+    });
+  }
+
+  /* ========================================
+   * COMPUTED PROPERTIES - DISPLAY STATE
+   * Control flag and option rendering
+   * ======================================== */
+
+  /**
+   * Determines if required/optional flag should display.
+   *
+   * @returns {boolean} True if required or optional is set
+   * @template-binding: <span lwc:if={showFlag}>
+   */
+  get showFlag() {
+    return this._propSetMap?.required || this._propSetMap?.optional;
+  }
+
+  /**
+   * Returns announcement text for screen readers when results are available.
+   * AODA/WCAG: Provides dynamic result count for assistive technology.
+   *
+   * @returns {string} Announcement text
+   * @template-binding: Used in aria-live region
+   */
+  get resultsAnnouncement() {
+    if (this.isPageLoading) {
+      return "Loading options...";
+    }
+    const count = this.computedOptions?.length || 0;
+    if (count === 0) {
+      return "No options available";
+    }
+    return `${count} option${count === 1 ? "" : "s"} available. Use up and down arrows to navigate.`;
+  }
+
+  /**
+   * Returns the flag text ("required" or "optional").
+   *
+   * @returns {string} Flag text for display
+   * @template-binding: ({flagText})
+   */
+  get flagText() {
+    if (this._propSetMap?.required) return "required";
+    if (this._propSetMap?.optional) return "optional";
+    return "";
+  }
+
+  /**
+   * Transforms options for template rendering.
+   * Marks clear option and adds href for each option.
+   *
+   * The "--" value is a special OmniStudio convention for "clear selection".
+   * This getter transforms it to a user-friendly label.
+   *
+   * @returns {Array} Decorated options with isClear and href properties
+   * @template-binding: Used in option iteration (for:each)
+   * @override
+   */
+  get computedOptions() {
+    const rv = super.computedOptions;
+
+    for (let i = 0; i < rv.length; i++) {
+      const item = rv[i];
+      // Transform the clear option marker to friendly label
+      if (item.value === "--") {
+        item.isClear = true;
+        item.value = I18N.clearLabel;
+      }
+      // Add href for keyboard navigation
+      item.href = `#option-${item.id}`;
+    }
+
+    return rv;
+  }
+
+  /* ========================================
+   * DROPDOWN BEHAVIOR OVERRIDES
+   * Customize show/hide with Ontario styling
+   * ======================================== */
+
+  /**
+   * Opens the dropdown and applies Ontario open state class.
+   * Resets selection if clearValue is enabled.
+   *
+   * @override
+   */
+  showOptions() {
+    log.enter("showOptions");
+
+    // Apply open class to trigger container
+    const triggerEl = this.template.querySelector(".sfgpsdscaon-combobox");
+    if (triggerEl) {
+      triggerEl.classList.add(THEME_IS_OPEN_CLASSNAME);
+    }
+
+    // Call parent to handle standard show logic
+    super.showOptions();
+
+    // Reset selection state if clear is enabled
+    if (this.selectedIndex === -1 || this._propSetMap.clearValue) {
+      log.debug("Resetting selection state", {
+        clearValue: this._propSetMap.clearValue
+      });
+      this.selectedIndex = -1;
+      this.highlightIndex = -1;
+      this.ariaFocus(null);
+    }
+
+    log.debug("Dropdown opened", {
+      optionCount: this.computedOptions?.length || 0
+    });
+    log.exit("showOptions");
+  }
+
+  /**
+   * Closes the dropdown and removes Ontario open state class.
+   *
+   * @override
+   */
+  hideOptions() {
+    // Remove open class from trigger container
+    const triggerEl = this.template.querySelector(".sfgpsdscaon-combobox");
+    if (triggerEl) {
+      triggerEl.classList.remove(THEME_IS_OPEN_CLASSNAME);
+    }
+
+    // Call parent to handle standard hide logic
+    super.hideOptions();
+  }
+
+  /**
+   * Manages visual focus indicator on options.
+   * Implements ARIA activedescendant pattern for screen readers.
+   *
+   * This is critical for WCAG compliance - screen readers need to
+   * know which option is currently focused even though DOM focus
+   * remains on the input.
+   *
+   * @param {number|null} newIndex - Index of option to focus, or null to clear
+   * @param {boolean} [isHover=false] - True if triggered by mouse hover
+   * @override
+   */
+  ariaFocus(newIndex, isHover = false) {
+    const options = this.template.querySelectorAll('[role="option"]');
+
+    // Remove focus styling from all options
+    options.forEach((opt) => {
+      opt.classList.remove(THEME_HAS_FOCUS_CLASSNAME);
+    });
+
+    if (newIndex != null && options[newIndex]) {
+      const option = options[newIndex];
+
+      // Apply focus styling
+      option.classList.add(THEME_HAS_FOCUS_CLASSNAME);
+
+      // Update ARIA activedescendant for screen readers
+      this._inputRef.setAttribute("aria-activedescendant", option.id);
+
+      // Scroll into view for keyboard navigation (not for hover)
+      if (option.scrollIntoView && !isHover) {
+        option.scrollIntoView({ block: "nearest" });
+      }
+    } else if (options.length) {
+      // Scroll to first option when clearing focus
+      if (options[0].scrollIntoView && !isHover) {
+        options[0].scrollIntoView({ block: "nearest" });
+      }
+    }
+  }
+
+  /* ========================================
+   * EVENT HANDLERS
+   * Handle user interactions
+   * ======================================== */
+
+  /**
+   * Handles option selection from the dropdown.
+   * Prevents default anchor behavior before calling parent handler.
+   *
+   * @param {Event} event - Click event from option element
+   * @override
+   */
+  selectOption(event) {
+    log.enter("selectOption");
+
+    // Prevent anchor navigation
+    event.preventDefault();
+
+    const optionIndex = event.currentTarget?.dataset?.index;
+    log.debug("Option selected", { index: optionIndex });
+
+    try {
+      // Call parent to update value and close dropdown
+      super.selectOption(event);
+      log.debug("Selection applied successfully");
+    } catch (error) {
+      log.error("Failed to apply selection", error);
+    }
+
+    log.exit("selectOption");
+  }
+
+  /* ========================================
+   * LIFECYCLE METHODS
+   * Component initialization
+   * ======================================== */
+
+  /**
+   * Returns the Ontario DS template for this component.
+   *
+   * @returns {Object} The template to render
+   * @override
+   */
+  render() {
+    return tmpl;
+  }
+
+  /**
+   * Initializes component with Ontario DS classes.
+   * Sets up CSS scoping and read-only styling class.
+   *
+   * @override
+   */
+  connectedCallback() {
+    log.enter("connectedCallback");
+    log.timeStart("initialization");
+
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    // Class used for read-only styling
+    this._readOnlyClass = "sfgpsdscaon-read-only";
+
+    // CSS scoping class for Ontario DS styles
+    this.classList.add("caon-scope");
+
+    log.debug("Component initialized", {
+      label: this._propSetMap?.label,
+      required: this._propSetMap?.required,
+      optionsSource: this._propSetMap?.optionSource?.type || "none"
+    });
+
+    log.timeEnd("initialization");
+    log.exit("connectedCallback");
+  }
+
+  /**
+   * Cleanup when component is removed.
+   *
+   * @override
+   */
+  disconnectedCallback() {
+    log.debug("Component disconnecting");
+
+    if (super.disconnectedCallback) {
+      super.disconnectedCallback();
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormLookup/sfGpsDsCaOnFormLookup.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormLookup/sfGpsDsCaOnFormLookup.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Lookup for OmniStudio standard runtime forms. Provides searchable dropdown with autocomplete. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMessaging/sfGpsDsCaOnFormMessaging.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMessaging/sfGpsDsCaOnFormMessaging.html
@@ -1,0 +1,45 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System - Messaging Component for OmniStudio
+  
+  Displays alert messages using Ontario DS page alerts.
+  Supports Markdown content including hyperlinks for hard stop messages.
+  
+  Maps OmniStudio message types to Ontario alert types:
+  - Success -> success (green)
+  - Requirement -> error (red/pink, used for hard stops)
+  - Warning -> warning (yellow)
+  - Comment -> informational (blue)
+  
+  Markdown Support:
+  - Links: [link text](url)
+  - Bold: **bold text**
+  - Italic: *italic text*
+  - Paragraphs: separated by blank lines
+  
+  Example Message Text:
+  "Based on your answer, you may need to [apply for an ECA](https://ontario.ca/eca)."
+  
+  Compliance:
+  - LWR: Compatible (uses Ontario DS web component with lwc:external)
+  - LWS: Compatible (no restricted APIs)
+  - Ontario DS: Uses ontario-page-alert component
+  - WCAG 2.1 AA: 
+    - Uses proper alert roles
+    - Accessible color contrast
+    - Screen reader compatible
+    - Links are keyboard accessible
+-->
+<template>
+  <template lwc:if={hasContent}>
+    <div class="ontario-form-group sfgpsdscaon-messaging">
+      <ontario-page-alert
+        lwc:external
+        type={ontarioAlertType}
+        heading={mergedTitleText}
+      >
+        <span lwc:ref="content" lwc:dom="manual"></span>
+      </ontario-page-alert>
+    </div>
+  </template>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMessaging/sfGpsDsCaOnFormMessaging.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMessaging/sfGpsDsCaOnFormMessaging.js
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import SfGpsDsFormMessaging from "c/sfGpsDsFormMessaging";
+import { replaceInnerHtml } from "c/sfGpsDsHelpers";
+import mdEngine from "c/sfGpsDsMarkdown";
+import tmpl from "./sfGpsDsCaOnFormMessaging.html";
+
+// Debug flag - set to true to enable console logging
+const DEBUG = false;
+const CLASS_NAME = "SfGpsDsCaOnFormMessaging";
+
+/**
+ * @slot Messaging
+ * @description Ontario Design System Messaging component for OmniStudio forms.
+ * Displays alert messages using Ontario DS page alerts.
+ * Supports Success, Requirement (Error), Warning, and Comment (Info) message types.
+ *
+ * Features:
+ * - Supports Markdown content including links, bold, italic, lists
+ * - Automatically renders hyperlinks in message text
+ * - Maps OmniStudio message types to Ontario alert styles
+ *
+ * Compliance:
+ * - LWR: Uses Light DOM parent component
+ * - LWS: No eval(), proper namespace imports
+ * - Ontario DS: Uses ontario-page-alert web component
+ * - WCAG 2.1 AA: Alert role for screen readers, proper color contrast
+ *
+ * @example
+ * // In OmniScript, configure a Messaging element with:
+ * // Message Type: Requirement (for hard stop errors)
+ * // Message Text: "Based on your answer, you may need to [apply for an ECA](https://example.com)."
+ */
+export default class SfGpsDsCaOnFormMessaging extends SfGpsDsFormMessaging {
+  /* private */
+
+  _messageHtml = "";
+
+  /* computed */
+
+  /**
+   * Maps OmniStudio message types to Ontario DS alert types
+   * @returns {string} Ontario alert type: success, error, warning, or informational
+   */
+  get ontarioAlertType() {
+    if (this.isSuccess) return "success";
+    if (this.isRequirement) return "error";
+    if (this.isWarning) return "warning";
+    if (this.isComment) return "informational";
+    return "informational";
+  }
+
+  /**
+   * Gets the merged title text from OmniScript properties
+   * @returns {string} Title text for the alert heading
+   */
+  get mergedTitleText() {
+    return this._propSetMap?.titleText || "";
+  }
+
+  /**
+   * Gets the merged message text from OmniScript properties
+   * @returns {string} Message text (may contain Markdown)
+   */
+  get mergedMessageText() {
+    return this._propSetMap?.messageText || "";
+  }
+
+  /**
+   * Check if message text exists
+   * @returns {string|undefined} Message text or undefined
+   */
+  get messageText() {
+    return this._propSetMap?.messageText;
+  }
+
+  /**
+   * Check if we have content to display
+   * @returns {boolean} True if there is message content
+   */
+  get hasContent() {
+    return Boolean(this.messageText);
+  }
+
+  /* methods */
+
+  /**
+   * Parses Markdown content and converts to HTML
+   * Supports: links, bold, italic, lists, paragraphs
+   * @param {string} markdown - Markdown text to parse
+   * @returns {string} HTML string
+   */
+  parseMarkdown(markdown) {
+    if (!markdown) return "";
+
+    try {
+      // Use the markdown engine to convert to HTML
+      const html = mdEngine.renderInline(markdown);
+      if (DEBUG) console.log(CLASS_NAME, "parseMarkdown", { markdown, html });
+      return html;
+    } catch (error) {
+      console.error(CLASS_NAME, "Error parsing markdown:", error);
+      // Fallback to plain text if parsing fails
+      return markdown;
+    }
+  }
+
+  /**
+   * Updates the message HTML content
+   * Called when the component renders or message changes
+   */
+  updateMessageContent() {
+    const contentRef = this.refs?.content;
+    if (contentRef && this.messageText) {
+      const html = this.parseMarkdown(this.messageText);
+      if (html !== this._messageHtml) {
+        this._messageHtml = html;
+        replaceInnerHtml(contentRef, html);
+        if (DEBUG) console.log(CLASS_NAME, "updateMessageContent", { html });
+      }
+    }
+  }
+
+  /* lifecycle */
+
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    this.classList.add("caon-scope");
+
+    if (DEBUG) console.log(CLASS_NAME, "connectedCallback", this._propSetMap);
+  }
+
+  renderedCallback() {
+    if (super.renderedCallback) {
+      super.renderedCallback();
+    }
+
+    this.updateMessageContent();
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMessaging/sfGpsDsCaOnFormMessaging.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMessaging/sfGpsDsCaOnFormMessaging.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario DS Messaging for OmniStudio. Alert messages with Markdown and hyperlink support. For success, warning, and hard stop messages.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMultiselect/sfGpsDsCaOnFormMultiselect.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMultiselect/sfGpsDsCaOnFormMultiselect.css
@@ -1,0 +1,119 @@
+.ontario-fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0 0 1.5rem 0;
+  min-width: 0;
+}
+.ontario-fieldset__legend {
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+  padding: 0;
+  display: block;
+}
+.ontario-label__flag {
+  font-weight: 400;
+}
+.ontario-hint {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+.ontario-checkboxes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.ontario-checkboxes__item {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+}
+.ontario-checkboxes__input {
+  position: absolute;
+  opacity: 0;
+  width: 2rem;
+  height: 2rem;
+  cursor: pointer;
+}
+.ontario-checkboxes__label {
+  display: block;
+  padding-left: 2.5rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+  cursor: pointer;
+  position: relative;
+}
+.ontario-checkboxes__label::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 2rem;
+  height: 2rem;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+  background: #fff;
+}
+.ontario-checkboxes__input:checked + .ontario-checkboxes__label::before {
+  background: #1a1a1a;
+}
+.ontario-checkboxes__input:checked + .ontario-checkboxes__label::after {
+  content: "";
+  position: absolute;
+  left: 0.5rem;
+  top: 0.25rem;
+  width: 0.75rem;
+  height: 1.25rem;
+  border: solid #fff;
+  border-width: 0 3px 3px 0;
+  transform: rotate(45deg);
+}
+.ontario-checkboxes__input:focus + .ontario-checkboxes__label::before {
+  outline: 4px solid #009ade;
+  outline-offset: 0;
+  box-shadow: 0 0 0 4px #009ade;
+}
+.ontario-checkboxes__input:disabled + .ontario-checkboxes__label {
+  color: #666;
+  cursor: not-allowed;
+}
+.ontario-checkboxes__input:disabled + .ontario-checkboxes__label::before {
+  border-color: #666;
+  background: #e6e6e6;
+}
+.ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #cd0000;
+  margin-bottom: 0.5rem;
+}
+.ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  fill: #cd0000;
+}
+.ontario-error-messaging__content {
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+/* Visually hidden input for validation - still participates in Constraint Validation */
+.sfgpsdscaon-validation-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMultiselect/sfGpsDsCaOnFormMultiselect.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMultiselect/sfGpsDsCaOnFormMultiselect.html
@@ -1,0 +1,78 @@
+<!-- sldsValidatorIgnore -->
+<template>
+  <fieldset
+    class={computedFieldsetClassName}
+    aria-describedby={computedAriaDescribedBy}
+    aria-invalid={computedAriaInvalid}
+    aria-required={computedAriaRequired}
+  >
+    <legend class="ontario-fieldset__legend">
+      {mergedLabel}
+      <span lwc:if={showRequiredFlag} class="ontario-label__flag"
+        >(required)</span
+      >
+      <span lwc:if={showOptionalFlag} class="ontario-label__flag"
+        >(optional)</span
+      >
+    </legend>
+
+    <p lwc:if={mergedHelpText} id={hintId} class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <div
+      lwc:if={sfGpsDsIsError}
+      id={errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <!-- Visually hidden input for validation - holds aggregated value -->
+    <!-- Uses text type (not hidden) so it participates in Constraint Validation -->
+    <input
+      type="text"
+      class="sfgpsdscaon-validation-input"
+      data-omni-input
+      value={elementValue}
+      required={_propSetMap.required}
+      aria-hidden="true"
+      tabindex="-1"
+    />
+
+    <div class="ontario-checkboxes">
+      <template for:each={inlineDecoratedOptions} for:item="opt">
+        <div class="ontario-checkboxes__item" key={opt.value}>
+          <input
+            type="checkbox"
+            class="ontario-checkboxes__input"
+            id={opt.id}
+            name={_name}
+            value={opt.value}
+            checked={opt.checked}
+            disabled={_propSetMap.readOnly}
+            onchange={handleCheckboxChange}
+            onblur={handleBlur}
+          />
+          <label class="ontario-checkboxes__label" for={opt.id}
+            >{opt.label}</label
+          >
+        </div>
+      </template>
+    </div>
+  </fieldset>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMultiselect/sfGpsDsCaOnFormMultiselect.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMultiselect/sfGpsDsCaOnFormMultiselect.js
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import { api, track } from "lwc";
+import SfGpsDsFormMultiselect from "c/sfGpsDsFormMultiselect";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormMultiselect.html";
+
+const DEBUG = true;
+const CLASS_NAME = "SfGpsDsCaOnFormMultiselect";
+
+export default class SfGpsDsCaOnFormMultiselect extends SfGpsDsFormMultiselect {
+  _uniqueId = `multiselect-${Math.random().toString(36).substring(2, 11)}`;
+
+  // Flag to track when we're in the middle of applying a value
+  // This allows us to return true from validation during value updates
+  _isApplyingValue = false;
+
+  // Tracked properties for error display (triggers reactivity)
+  @track isError = false;
+  @track errorMessage = "";
+
+  /* IDs */
+  get hintId() {
+    return `${this._uniqueId}-hint`;
+  }
+  get errorId() {
+    return `${this._uniqueId}-error`;
+  }
+
+  /* Computed properties */
+  get showRequiredFlag() {
+    return this._propSetMap?.required === true;
+  }
+  get showOptionalFlag() {
+    return this._propSetMap?.optional === true && !this._propSetMap?.required;
+  }
+  get computedAriaRequired() {
+    return this._propSetMap?.required ? "true" : "false";
+  }
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+
+  /**
+   * Returns true if the component is in an error state.
+   * Used by the template to show/hide the error container.
+   */
+  get sfGpsDsIsError() {
+    return this.isError || this._sfGpsDsCustomValidation;
+  }
+
+  /**
+   * Returns the error message to display.
+   * Used by the template for the error message content.
+   */
+  get sfGpsDsErrorMessage() {
+    return this._sfGpsDsCustomValidation || this.errorMessage;
+  }
+
+  get computedAriaDescribedBy() {
+    return computeClass({
+      [this.hintId]: this.mergedHelpText,
+      [this.errorId]: this.sfGpsDsIsError
+    });
+  }
+
+  get computedFieldsetClassName() {
+    return computeClass({
+      "ontario-fieldset": true,
+      "ontario-fieldset--error": this.sfGpsDsIsError
+    });
+  }
+
+  /**
+   * Parses elementValue which can be a semicolon-delimited string or array.
+   * @returns {string[]} Array of selected values
+   */
+  get _selectedValues() {
+    if (DEBUG) {
+      console.log(CLASS_NAME, "_selectedValues getter called");
+      console.log(CLASS_NAME, "  elementValue:", this.elementValue);
+      console.log(
+        CLASS_NAME,
+        "  typeof elementValue:",
+        typeof this.elementValue
+      );
+    }
+    if (!this.elementValue) return [];
+    if (Array.isArray(this.elementValue)) return this.elementValue;
+    if (typeof this.elementValue === "string") {
+      return this.elementValue.split(";").filter((v) => v);
+    }
+    return [this.elementValue.toString()];
+  }
+
+  get inlineDecoratedOptions() {
+    if (DEBUG) {
+      console.log(CLASS_NAME, "inlineDecoratedOptions getter called");
+      console.log(CLASS_NAME, "  _realtimeOptions:", this._realtimeOptions);
+      console.log(CLASS_NAME, "  _options:", this._options);
+    }
+
+    const selected = this._selectedValues;
+
+    if (DEBUG) console.log(CLASS_NAME, "  selected values:", selected);
+
+    return (this._realtimeOptions || []).map((opt, index) => {
+      // OmniScript convention: opt.name is the identifier/value to store,
+      // opt.value is the display label
+      const optValue = opt.name || opt.value || opt.label;
+      const optLabel = opt.value || opt.label || opt.name;
+
+      if (DEBUG && index === 0) {
+        console.log(CLASS_NAME, "  first option raw:", opt);
+        console.log(CLASS_NAME, "  first option optValue:", optValue);
+        console.log(CLASS_NAME, "  first option optLabel:", optLabel);
+      }
+
+      return {
+        ...opt,
+        value: optValue,
+        label: optLabel,
+        id: `${this._uniqueId}-opt-${index}`,
+        checked: selected.includes(optValue)
+      };
+    });
+  }
+
+  /* Event handlers */
+
+  /**
+   * Handles change events from the native checkbox elements.
+   * Aggregates selected values and updates OmniScript data.
+   * Follows the same pattern as sfGpsDsCaOnFormSelect.
+   * @param {Event} event - The change event from a checkbox element
+   */
+  handleCheckboxChange(event) {
+    if (DEBUG) console.log(CLASS_NAME, "handleCheckboxChange called");
+
+    const checkbox = event.target;
+    const value = checkbox.value;
+    const checked = checkbox.checked;
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "  checkbox value:", value);
+      console.log(CLASS_NAME, "  checkbox checked:", checked);
+      console.log(
+        CLASS_NAME,
+        "  current elementValue before:",
+        this.elementValue
+      );
+    }
+
+    // Get current selected values as array
+    let currentValues = [...this._selectedValues];
+
+    if (DEBUG)
+      console.log(
+        CLASS_NAME,
+        "  currentValues before modification:",
+        currentValues
+      );
+
+    if (checked) {
+      if (!currentValues.includes(value)) {
+        currentValues.push(value);
+      }
+    } else {
+      currentValues = currentValues.filter((v) => v !== value);
+    }
+
+    if (DEBUG)
+      console.log(
+        CLASS_NAME,
+        "  currentValues after modification:",
+        currentValues
+      );
+
+    // Update OmniScript data - use semicolon-delimited string format
+    // This follows the same pattern as sfGpsDsCaOnFormSelect.handleChange
+    const valueString = currentValues.join(";");
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "  valueString to apply:", valueString);
+      console.log(CLASS_NAME, "  calling applyCallResp...");
+      console.log(
+        CLASS_NAME,
+        "  applyCallResp exists:",
+        typeof this.applyCallResp
+      );
+    }
+
+    // Set flag to allow value to be applied without validation blocking it
+    this._isApplyingValue = true;
+
+    // Update the validation input's value BEFORE calling applyCallResp
+    const validationInput = this.template.querySelector(
+      "input.sfgpsdscaon-validation-input"
+    );
+    if (validationInput) {
+      validationInput.value = valueString;
+      if (DEBUG)
+        console.log(CLASS_NAME, "  validationInput.value set to:", valueString);
+    }
+
+    this.applyCallResp(valueString);
+
+    // Clear the flag
+    this._isApplyingValue = false;
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "  applyCallResp called");
+      console.log(
+        CLASS_NAME,
+        "  elementValue after applyCallResp:",
+        this.elementValue
+      );
+    }
+  }
+
+  /**
+   * Handles blur events from checkbox elements.
+   * Triggers validation when a checkbox loses focus.
+   */
+  handleBlur() {
+    this.reportValidity();
+  }
+
+  /* Validation */
+
+  /**
+   * Helper to check if multiselect has any selected values.
+   * @returns {boolean} True if at least one option is selected
+   */
+  _hasSelection() {
+    const val = this.elementValue;
+    if (!val) return false;
+    if (Array.isArray(val)) return val.length > 0;
+    if (typeof val === "string") return val.trim().length > 0;
+    return true;
+  }
+
+  /**
+   * Checks if the multiselect is valid.
+   * Returns true during value updates to prevent blocking applyCallResp.
+   * @returns {boolean} True if valid or if applying value, false otherwise
+   */
+  @api checkValidity() {
+    // During value updates, always return true to allow the value to be applied
+    if (this._isApplyingValue) {
+      if (DEBUG)
+        console.log(
+          CLASS_NAME,
+          "checkValidity: returning true (applying value)"
+        );
+      return true;
+    }
+
+    const isRequired = this._propSetMap?.required === true;
+    const hasValue = this._hasSelection();
+    const valid = !isRequired || hasValue;
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "checkValidity called");
+      console.log(CLASS_NAME, "  isRequired:", isRequired);
+      console.log(CLASS_NAME, "  hasValue:", hasValue);
+      console.log(CLASS_NAME, "  valid:", valid);
+    }
+
+    // Set isValid to dispatch validation event to OmniScript
+    this.isValid = valid;
+
+    return valid;
+  }
+
+  /**
+   * Reports validity and updates the error state.
+   * Returns true during value updates to prevent blocking applyCallResp.
+   * @returns {boolean} True if valid or if applying value, false otherwise
+   */
+  @api reportValidity() {
+    // During value updates, always return true to allow the value to be applied
+    if (this._isApplyingValue) {
+      if (DEBUG)
+        console.log(
+          CLASS_NAME,
+          "reportValidity: returning true (applying value)"
+        );
+      return true;
+    }
+
+    const valid = this.checkValidity();
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "reportValidity called");
+      console.log(CLASS_NAME, "  valid:", valid);
+    }
+
+    // Update error display state - this is what sfGpsDsIsError uses
+    this.isError = !valid;
+    this._showValidation = !valid;
+
+    // Set error message when invalid
+    if (!valid) {
+      this.errorMessage =
+        this.mergedMessageWhenValueMissing ||
+        this._messageWhenValueMissing ||
+        "This field is required";
+    } else {
+      this.errorMessage = "";
+    }
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "  isError:", this.isError);
+      console.log(CLASS_NAME, "  errorMessage:", this.errorMessage);
+    }
+
+    return valid;
+  }
+
+  /* Lifecycle */
+
+  /**
+   * Initialize component variables.
+   * Sets the input selector for the parent validation framework.
+   */
+  initCompVariables() {
+    if (DEBUG) console.log(CLASS_NAME, "initCompVariables called");
+    super.initCompVariables();
+    // Set the selector so the parent class can find our validation input
+    // Uses a visually hidden text input (not type="hidden") for Constraint Validation API support
+    this._inputSelector = "input.sfgpsdscaon-validation-input[data-omni-input]";
+    if (DEBUG) {
+      console.log(CLASS_NAME, "  _inputSelector set to:", this._inputSelector);
+      console.log(CLASS_NAME, "  jsonDef:", this.jsonDef);
+      console.log(CLASS_NAME, "  _propSetMap:", this._propSetMap);
+    }
+  }
+
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (DEBUG) console.log(CLASS_NAME, "connectedCallback called");
+    if (super.connectedCallback) super.connectedCallback();
+    this._readOnlyClass = "sfgpsdscaon-read-only";
+    this.classList.add("caon-scope");
+    if (DEBUG) {
+      console.log(CLASS_NAME, "  connectedCallback complete");
+      console.log(CLASS_NAME, "  elementValue:", this.elementValue);
+      console.log(CLASS_NAME, "  _realtimeOptions:", this._realtimeOptions);
+    }
+  }
+
+  _hasRendered = false;
+
+  renderedCallback() {
+    if (super.renderedCallback) super.renderedCallback();
+
+    // On first render, check validity to set initial validation state
+    // This ensures OmniScript knows if the field is initially invalid
+    if (!this._hasRendered) {
+      this._hasRendered = true;
+
+      // Defer to allow DOM to settle
+      // eslint-disable-next-line @lwc/lwc/no-async-operation
+      Promise.resolve().then(() => {
+        // Check validity without showing errors (user hasn't interacted yet)
+        // This dispatches the VALID/INVALID event to OmniScript
+        this.checkValidity();
+
+        if (DEBUG) {
+          console.log(CLASS_NAME, "renderedCallback: initial validity checked");
+          console.log(CLASS_NAME, "  isValid:", this.isValid);
+        }
+      });
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMultiselect/sfGpsDsCaOnFormMultiselect.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormMultiselect/sfGpsDsCaOnFormMultiselect.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Multiselect for OmniStudio standard runtime forms. Uses checkbox group pattern. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormNumber/sfGpsDsCaOnFormNumber.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormNumber/sfGpsDsCaOnFormNumber.css
@@ -1,0 +1,64 @@
+.ontario-form-group {
+  margin-bottom: 1.5rem;
+}
+.ontario-label {
+  display: block;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+}
+.ontario-label__flag {
+  font-weight: 400;
+}
+.ontario-hint {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+.ontario-input {
+  display: block;
+  width: 100%;
+  max-width: 48rem;
+  padding: 0.625rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background-color: #fff;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+}
+.ontario-input:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 0;
+  box-shadow: 0 0 0 4px #009ade;
+}
+.ontario-input:disabled {
+  background-color: #e6e6e6;
+  border-color: #666;
+  color: #666;
+  cursor: not-allowed;
+}
+.ontario-input__error {
+  border-color: #cd0000;
+}
+.ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #cd0000;
+  margin-bottom: 0.5rem;
+}
+.ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  fill: #cd0000;
+}
+.ontario-error-messaging__content {
+  font-size: 1rem;
+  line-height: 1.5;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormNumber/sfGpsDsCaOnFormNumber.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormNumber/sfGpsDsCaOnFormNumber.html
@@ -1,0 +1,62 @@
+<!-- sldsValidatorIgnore -->
+<template>
+  <div class="ontario-form-group">
+    <label class="ontario-label" for={inputId}>
+      {mergedLabel}
+      <span lwc:if={showRequiredFlag} class="ontario-label__flag"
+        >(required)</span
+      >
+      <span lwc:if={showOptionalFlag} class="ontario-label__flag"
+        >(optional)</span
+      >
+    </label>
+
+    <p lwc:if={mergedHelpText} id={hintId} class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <div
+      lwc:if={sfGpsDsIsError}
+      id={errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <input
+      type="number"
+      id={inputId}
+      name={_name}
+      class={computedInputClassName}
+      value={elementValue}
+      placeholder={mergedPlaceholder}
+      disabled={_propSetMap.disabled}
+      readonly={_propSetMap.readOnly}
+      required={_propSetMap.required}
+      aria-required={computedAriaRequired}
+      min={_min}
+      max={_max}
+      step={_step}
+      aria-describedby={computedAriaDescribedBy}
+      aria-invalid={computedAriaInvalid}
+      data-omni-input
+      oninput={handleInput}
+      onchange={handleChange}
+      onblur={handleBlur}
+    />
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormNumber/sfGpsDsCaOnFormNumber.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormNumber/sfGpsDsCaOnFormNumber.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import SfGpsDsFormNumber from "c/sfGpsDsFormNumber";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormNumber.html";
+
+export default class SfGpsDsCaOnFormNumber extends SfGpsDsFormNumber {
+  _uniqueId = `number-${Math.random().toString(36).substring(2, 11)}`;
+
+  get inputId() {
+    return `${this._uniqueId}-input`;
+  }
+  get hintId() {
+    return `${this._uniqueId}-hint`;
+  }
+  get errorId() {
+    return `${this._uniqueId}-error`;
+  }
+  get showRequiredFlag() {
+    return this._propSetMap?.required === true;
+  }
+  get showOptionalFlag() {
+    return this._propSetMap?.optional === true && !this._propSetMap?.required;
+  }
+  get computedInputClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "ontario-input__error": this.sfGpsDsIsError
+    });
+  }
+  get computedAriaDescribedBy() {
+    return computeClass({
+      [this.hintId]: this.mergedHelpText,
+      [this.errorId]: this.sfGpsDsIsError
+    });
+  }
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+  get computedAriaRequired() {
+    return this._propSetMap?.required ? "true" : "false";
+  }
+
+  render() {
+    return tmpl;
+  }
+  connectedCallback() {
+    if (super.connectedCallback) super.connectedCallback();
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormNumber/sfGpsDsCaOnFormNumber.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormNumber/sfGpsDsCaOnFormNumber.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Number input for OmniStudio standard runtime forms. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPassword/sfGpsDsCaOnFormPassword.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPassword/sfGpsDsCaOnFormPassword.css
@@ -1,0 +1,64 @@
+.ontario-form-group {
+  margin-bottom: 1.5rem;
+}
+.ontario-label {
+  display: block;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+}
+.ontario-label__flag {
+  font-weight: 400;
+}
+.ontario-hint {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+.ontario-input {
+  display: block;
+  width: 100%;
+  max-width: 48rem;
+  padding: 0.625rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background-color: #fff;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+}
+.ontario-input:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 0;
+  box-shadow: 0 0 0 4px #009ade;
+}
+.ontario-input:disabled {
+  background-color: #e6e6e6;
+  border-color: #666;
+  color: #666;
+  cursor: not-allowed;
+}
+.ontario-input__error {
+  border-color: #cd0000;
+}
+.ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #cd0000;
+  margin-bottom: 0.5rem;
+}
+.ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  fill: #cd0000;
+}
+.ontario-error-messaging__content {
+  font-size: 1rem;
+  line-height: 1.5;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPassword/sfGpsDsCaOnFormPassword.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPassword/sfGpsDsCaOnFormPassword.html
@@ -1,0 +1,60 @@
+<!-- sldsValidatorIgnore -->
+<template>
+  <div class="ontario-form-group">
+    <label class="ontario-label" for={inputId}>
+      {mergedLabel}
+      <span lwc:if={showRequiredFlag} class="ontario-label__flag"
+        >(required)</span
+      >
+      <span lwc:if={showOptionalFlag} class="ontario-label__flag"
+        >(optional)</span
+      >
+    </label>
+
+    <p lwc:if={mergedHelpText} id={hintId} class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <div
+      lwc:if={sfGpsDsIsError}
+      id={errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <input
+      type="password"
+      id={inputId}
+      name={_name}
+      class={computedInputClassName}
+      value={elementValue}
+      placeholder={mergedPlaceholder}
+      disabled={_propSetMap.disabled}
+      readonly={_propSetMap.readOnly}
+      required={_propSetMap.required}
+      aria-required={computedAriaRequired}
+      autocomplete={_autocomplete}
+      aria-describedby={computedAriaDescribedBy}
+      aria-invalid={computedAriaInvalid}
+      data-omni-input
+      oninput={handleInput}
+      onchange={handleChange}
+      onblur={handleBlur}
+    />
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPassword/sfGpsDsCaOnFormPassword.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPassword/sfGpsDsCaOnFormPassword.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import SfGpsDsFormPassword from "c/sfGpsDsFormPassword";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormPassword.html";
+
+export default class SfGpsDsCaOnFormPassword extends SfGpsDsFormPassword {
+  _uniqueId = `password-${Math.random().toString(36).substring(2, 11)}`;
+
+  get inputId() {
+    return `${this._uniqueId}-input`;
+  }
+  get hintId() {
+    return `${this._uniqueId}-hint`;
+  }
+  get errorId() {
+    return `${this._uniqueId}-error`;
+  }
+  get showRequiredFlag() {
+    return this._propSetMap?.required === true;
+  }
+  get showOptionalFlag() {
+    return this._propSetMap?.optional === true && !this._propSetMap?.required;
+  }
+  get computedInputClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "ontario-input__error": this.sfGpsDsIsError
+    });
+  }
+  get computedAriaDescribedBy() {
+    return computeClass({
+      [this.hintId]: this.mergedHelpText,
+      [this.errorId]: this.sfGpsDsIsError
+    });
+  }
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+  get computedAriaRequired() {
+    return this._propSetMap?.required ? "true" : "false";
+  }
+
+  render() {
+    return tmpl;
+  }
+  connectedCallback() {
+    if (super.connectedCallback) super.connectedCallback();
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPassword/sfGpsDsCaOnFormPassword.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPassword/sfGpsDsCaOnFormPassword.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Password input for OmniStudio standard runtime forms. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPlacesTypeahead/sfGpsDsCaOnFormPlacesTypeahead.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPlacesTypeahead/sfGpsDsCaOnFormPlacesTypeahead.css
@@ -1,0 +1,130 @@
+/**
+ * Ontario Design System Places Typeahead Styles
+ * 
+ * Provides styling for Google Maps address autocomplete
+ * following Ontario Design System patterns.
+ */
+
+/* Wrapper positioning */
+.sfgpsdscaon-typeahead-wrapper {
+  position: relative;
+}
+
+/* Location icon in input */
+.sfgpsdscaon-typeahead__icon {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  fill: var(--ontario-colour-grey-dark, #4d4d4d);
+}
+
+/* Input with right padding for icon */
+.sfgpsdscaon-typeahead__input {
+  padding-right: 44px;
+}
+
+/* Dropdown container */
+.sfgpsdscaon-dropdown {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background-color: var(--ontario-colour-white, #ffffff);
+  border: 2px solid var(--ontario-colour-black, #1a1a1a);
+  border-top: none;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.sfgpsdscaon-dropdown--open {
+  display: block;
+}
+
+/* Dropdown list */
+.sfgpsdscaon-dropdown__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* Dropdown items */
+.sfgpsdscaon-dropdown__item {
+  padding: 12px 16px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--ontario-colour-grey-light, #e8e8e8);
+  transition: background-color 0.2s ease;
+}
+
+.sfgpsdscaon-dropdown__item:last-of-type {
+  border-bottom: none;
+}
+
+.sfgpsdscaon-dropdown__item:hover,
+.sfgpsdscaon-dropdown__item.sfgpsdscaon-has-focus {
+  background-color: var(--ontario-colour-grey-light, #f2f2f2);
+}
+
+/* Focus indicator for keyboard navigation */
+.sfgpsdscaon-dropdown__item:focus {
+  outline: 3px solid var(--ontario-colour-focus, #009acd);
+  outline-offset: -3px;
+  background-color: var(--ontario-colour-grey-light, #f2f2f2);
+}
+
+/* Item text */
+.sfgpsdscaon-dropdown__item-text {
+  display: block;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+/* Google Attribution - Required by API Terms */
+.sfgpsdscaon-dropdown__attribution {
+  padding: 8px 16px;
+  text-align: right;
+  background-color: var(--ontario-colour-grey-light, #f8f8f8);
+  border-top: 1px solid var(--ontario-colour-grey-light, #e8e8e8);
+}
+
+.sfgpsdscaon-google-attribution {
+  height: 16px;
+  width: auto;
+}
+
+/* Map container */
+.sfgpsdscaon-places-map {
+  margin-top: 16px;
+  border: 1px solid var(--ontario-colour-grey-dark, #4d4d4d);
+  border-radius: 4px;
+  overflow: hidden;
+  height: 250px;
+}
+
+/* Open state on container */
+.sfgpsdscaon-is-open .sfgpsdscaon-typeahead__input {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+/* Read-only state */
+.sfgpsdscaon-read-only .sfgpsdscaon-typeahead__input {
+  background-color: var(--ontario-colour-grey-light, #f2f2f2);
+  cursor: not-allowed;
+}
+
+/* Screen reader only class */
+.ontario-show-for-sr {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPlacesTypeahead/sfGpsDsCaOnFormPlacesTypeahead.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPlacesTypeahead/sfGpsDsCaOnFormPlacesTypeahead.html
@@ -1,0 +1,146 @@
+<!-- 
+  Ontario Design System Places Typeahead for OmniStudio
+  Provides Google Maps address autocomplete with Ontario DS styling.
+  
+  Accessibility:
+  - role="combobox" on input for screen readers
+  - aria-expanded indicates dropdown state
+  - aria-activedescendant tracks focused option
+  - aria-live region announces results
+  - Full keyboard navigation (Arrow keys, Enter, Escape)
+  
+  Google Maps:
+  - Displays Google attribution as required by API terms
+  - Optional embedded lightning-map for visual confirmation
+-->
+<template>
+  <div class="ontario-form-group sfgpsdscaon-places-typeahead">
+    <!-- Label -->
+    <label class={computedLabelClassName} for="places-input">
+      {mergedLabel}
+      <span lwc:if={showFlag} class="ontario-label__flag"> ({flagText}) </span>
+    </label>
+
+    <!-- Help Text / Hint -->
+    <span lwc:if={mergedHelpText} id="helper" class="ontario-hint">
+      {mergedHelpText}
+    </span>
+
+    <!-- Error Message -->
+    <div
+      lwc:if={sfGpsDsIsError}
+      id="errorMessageBlock"
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        alt=""
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+        preserveAspectRatio="xMidYMid meet"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        ></path>
+      </svg>
+      <span class="ontario-error-messaging__content">
+        {sfGpsDsErrorMessage}
+      </span>
+    </div>
+
+    <!-- Input with Dropdown -->
+    <div class="sfgpsdscaon-typeahead-wrapper">
+      <input
+        id="places-input"
+        type="text"
+        class={computedInputClassName}
+        value={elementValue}
+        placeholder={mergedPlaceholder}
+        autocomplete="off"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={_showOptions}
+        aria-haspopup="listbox"
+        aria-controls="places-listbox"
+        aria-required={_propSetMap.required}
+        aria-invalid={sfGpsDsIsError}
+        aria-describedby={computedAriaDescribedBy}
+        aria-activedescendant={computedAriaActiveDescendant}
+        data-omni-input
+        onkeyup={handleTypeahead}
+        onkeydown={handleInputKeyDown}
+        onfocus={handleInputChange}
+        onblur={handleBlur}
+      />
+
+      <!-- Search Icon -->
+      <span class="sfgpsdscaon-typeahead__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" width="24" height="24" focusable="false">
+          <path
+            d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
+          />
+        </svg>
+      </span>
+
+      <!-- Screen Reader Announcement -->
+      <div
+        class="ontario-show-for-sr"
+        aria-live="polite"
+        aria-atomic="true"
+        role="status"
+      >
+        <span lwc:if={_showOptions}>{resultsAnnouncement}</span>
+      </div>
+
+      <!-- Options Dropdown -->
+      <div
+        lwc:if={hasOptions}
+        id="places-listbox"
+        class={computedDropdownClassName}
+        role="listbox"
+        aria-label="Address suggestions"
+      >
+        <ul class="sfgpsdscaon-dropdown__list">
+          <template for:each={decoratedOptions} for:item="option">
+            <li
+              key={option.key}
+              id={option.id}
+              class="sfgpsdscaon-dropdown__item"
+              role="option"
+              aria-selected="false"
+              data-option-index={option.key}
+              data-place-id={option.place_id}
+              onclick={handleOptionSelect}
+              onkeydown={handleOptionSelect}
+              onmouseover={handleOptionFocus}
+            >
+              <span class="sfgpsdscaon-dropdown__item-text">
+                {option.label}
+              </span>
+            </li>
+          </template>
+
+          <!-- Google Attribution - Required by API Terms -->
+          <li class="sfgpsdscaon-dropdown__attribution" aria-hidden="true">
+            <img
+              src={_googleAttribution}
+              alt="Powered by Google"
+              class="sfgpsdscaon-google-attribution"
+            />
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Map Display -->
+    <div lwc:if={showMap} class={computedMapClassName}>
+      <lightning-map
+        map-markers={selectedPlace}
+        zoom-level={zoomLevel}
+      ></lightning-map>
+    </div>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPlacesTypeahead/sfGpsDsCaOnFormPlacesTypeahead.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPlacesTypeahead/sfGpsDsCaOnFormPlacesTypeahead.js
@@ -1,0 +1,532 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import SfGpsDsFormPlacesTypeahead from "c/sfGpsDsFormPlacesTypeahead";
+import { computeClass } from "c/sfGpsDsHelpers";
+import { omniGetMergedField } from "c/sfGpsDsOmniHelpers";
+import { Logger } from "c/sfGpsDsCaOnDebugUtils";
+import tmpl from "./sfGpsDsCaOnFormPlacesTypeahead.html";
+
+/**
+ * Logger instance for this component.
+ * Enable debug output by setting window.sfGpsDsCaOnDebug = true in console.
+ * @type {Logger}
+ */
+const log = new Logger("SfGpsDsCaOnFormPlacesTypeahead");
+
+/**
+ * CSS class applied when dropdown is open.
+ * @type {string}
+ */
+const THEME_IS_OPEN_CLASSNAME = "sfgpsdscaon-is-open";
+
+/**
+ * CSS class applied to the currently focused option.
+ * @type {string}
+ */
+const THEME_HAS_FOCUS_CLASSNAME = "sfgpsdscaon-has-focus";
+
+/**
+ * @slot PlacesTypeahead
+ * @description Ontario Design System Places Typeahead for OmniStudio forms.
+ * Provides Google Maps address autocomplete functionality with Ontario DS styling.
+ *
+ * ## Google Maps API Requirements
+ * - Requires Google Maps API key configured in OmniScript element properties
+ * - Uses Google Places Autocomplete API
+ * - Supports address component mapping via googleTransformation property
+ *
+ * ## Key Inherited Properties (from OmniscriptPlacesTypeahead)
+ * - `selectedPlace` {Array} - Currently selected place for lightning-map
+ * - `_placesService` {GooglePlacesService} - Service instance for API calls
+ * - `_sessionToken` {string} - Google billing session token
+ * - `_googleAttribution` {string} - Required Google branding image
+ * - `zoomLevel` {number} - Map zoom level
+ *
+ * ## Key Inherited Methods (from OmniscriptPlacesTypeahead)
+ * - `placeAutocomplete()` - Searches Google Places API
+ * - `placeDetails()` - Gets full address details
+ * - `applySelection()` - Applies selected place to OmniScript data
+ * - `transformResult()` - Maps address components to OmniScript fields
+ *
+ * ## Configuration Properties (set in OmniScript Designer)
+ * - `googleMapsAPIKey` - Your Google Maps API key
+ * - `googleAddressCountry` - Country bias for search results
+ * - `googleAddressTypes` - Types of places to search (e.g., "address")
+ * - `googleTransformation` - Mapping of address components to OmniScript fields
+ * - `hideMap` - Whether to hide the embedded map
+ *
+ * ## Compliance
+ * - **LWR**: Uses Light DOM parent component
+ * - **LWS**: No eval(), proper namespace imports, try/catch for window APIs
+ * - **Ontario DS**: Uses Ontario form field styling
+ * - **WCAG 2.1 AA**: Proper ARIA combobox pattern, keyboard navigation
+ *
+ * @see {@link sfGpsDsCaOnFormTypeahead} For non-Google typeahead
+ */
+export default class SfGpsDsCaOnFormPlacesTypeahead extends SfGpsDsFormPlacesTypeahead {
+  /**
+   * Track whether dropdown is showing.
+   * @type {boolean}
+   */
+  _showOptions = false;
+
+  /**
+   * Track loading state during remote calls.
+   * @type {boolean}
+   */
+  _isLoading = false;
+
+  /**
+   * Index of currently highlighted option for keyboard navigation.
+   * @type {number}
+   */
+  _highlightIndex = -1;
+
+  /* ========================================
+   * COMPUTED PROPERTIES - ERROR STATE
+   * ======================================== */
+
+  /**
+   * Returns true if the field has a validation error.
+   *
+   * @returns {boolean} True if field is invalid
+   */
+  get sfGpsDsIsError() {
+    if (this._showValidation && !this.isValid) {
+      return true;
+    }
+    if (this._sfGpsDsCustomValidation) {
+      return true;
+    }
+    if (this.errorMessage) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Returns the error message to display.
+   *
+   * @returns {string|null} Error message or null
+   */
+  get sfGpsDsErrorMessage() {
+    if (this.errorMessage) {
+      return omniGetMergedField(this, this.errorMessage);
+    }
+    if (this.validationMessage) {
+      return omniGetMergedField(this, this.validationMessage);
+    }
+    return null;
+  }
+
+  /* ========================================
+   * COMPUTED PROPERTIES - CSS CLASSES
+   * ======================================== */
+
+  /**
+   * Computes CSS classes for the label element.
+   *
+   * @returns {string} Space-separated CSS classes
+   */
+  get computedLabelClassName() {
+    return computeClass({
+      "ontario-label": true,
+      "ontario-label--required": this._propSetMap.required
+    });
+  }
+
+  /**
+   * Computes CSS classes for the input element.
+   *
+   * @returns {string} Space-separated CSS classes
+   */
+  get computedInputClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "sfgpsdscaon-typeahead__input": true,
+      "ontario-input__error": this.sfGpsDsIsError
+    });
+  }
+
+  /**
+   * Determines if required/optional flag should display.
+   *
+   * @returns {boolean} True if flag should show
+   */
+  get showFlag() {
+    return this._propSetMap?.required || this._propSetMap?.optional;
+  }
+
+  /**
+   * Returns the flag text ("required" or "optional").
+   *
+   * @returns {string} Flag text
+   */
+  get flagText() {
+    if (this._propSetMap?.required) return "required";
+    if (this._propSetMap?.optional) return "optional";
+    return "";
+  }
+
+  /**
+   * Computes aria-describedby for accessibility.
+   *
+   * @returns {string|null} Space-separated element IDs
+   */
+  get computedAriaDescribedBy() {
+    const ids = [];
+    if (this.mergedHelpText) ids.push("helper");
+    if (this.sfGpsDsIsError) ids.push("errorMessageBlock");
+    return ids.length > 0 ? ids.join(" ") : null;
+  }
+
+  /**
+   * Computes aria-activedescendant for the currently highlighted option.
+   *
+   * @returns {string|null} ID of highlighted option or null
+   */
+  get computedAriaActiveDescendant() {
+    if (
+      this._showOptions &&
+      this._highlightIndex >= 0 &&
+      this._highlightIndex < (this.options?.length || 0)
+    ) {
+      return `places-option-${this._highlightIndex}`;
+    }
+    return null;
+  }
+
+  /**
+   * Returns the number of available options.
+   *
+   * @returns {number} Number of options
+   */
+  get optionCount() {
+    return this.options?.length || 0;
+  }
+
+  /**
+   * Returns announcement text for screen readers.
+   *
+   * @returns {string} Announcement text
+   */
+  get resultsAnnouncement() {
+    if (this._isLoading) {
+      return "Searching addresses...";
+    }
+    const count = this.optionCount;
+    if (count === 0) {
+      return "No addresses found";
+    }
+    return `${count} address${count === 1 ? "" : "es"} found. Use up and down arrows to navigate.`;
+  }
+
+  /**
+   * Computes CSS classes for the dropdown container.
+   *
+   * @returns {string} Space-separated CSS classes
+   */
+  get computedDropdownClassName() {
+    return computeClass({
+      "sfgpsdscaon-dropdown": true,
+      "sfgpsdscaon-dropdown--open": this._showOptions
+    });
+  }
+
+  /**
+   * Returns true if options array has items.
+   *
+   * @returns {boolean} True if options exist
+   */
+  get hasOptions() {
+    return this.options && this.options.length > 0;
+  }
+
+  /**
+   * Transforms options for template rendering.
+   * Google Places returns predictions with `description` for display.
+   *
+   * @returns {Array} Decorated options with key, id, and label
+   */
+  get decoratedOptions() {
+    return (this.options || []).map((opt, index) => {
+      const optObj = typeof opt === "string" ? { description: opt } : opt;
+      return {
+        ...optObj,
+        key: optObj.place_id || index,
+        id: `places-option-${index}`,
+        // Google Places uses `description` for display text
+        label: optObj.description || optObj.name || ""
+      };
+    });
+  }
+
+  /**
+   * Returns true if the map should be rendered.
+   *
+   * @returns {boolean} True to show map
+   */
+  get showMap() {
+    return (
+      !this._propSetMap.hideMap &&
+      this.selectedPlace &&
+      this.selectedPlace.length > 0
+    );
+  }
+
+  /**
+   * Computes CSS classes for the map container.
+   *
+   * @returns {string} Space-separated CSS classes
+   */
+  get computedMapClassName() {
+    return computeClass({
+      "sfgpsdscaon-places-map": true,
+      "sfgpsdscaon-places-map--visible": this.showMap
+    });
+  }
+
+  /* ========================================
+   * DROPDOWN BEHAVIOR
+   * ======================================== */
+
+  /**
+   * Opens the dropdown.
+   */
+  showOptionsDropdown() {
+    this._showOptions = true;
+    const triggerEl = this.template.querySelector(
+      ".sfgpsdscaon-places-typeahead"
+    );
+    if (triggerEl) {
+      triggerEl.classList.add(THEME_IS_OPEN_CLASSNAME);
+    }
+  }
+
+  /**
+   * Closes the dropdown.
+   */
+  hideOptionsDropdown() {
+    this._showOptions = false;
+    this._highlightIndex = -1;
+    const triggerEl = this.template.querySelector(
+      ".sfgpsdscaon-places-typeahead"
+    );
+    if (triggerEl) {
+      triggerEl.classList.remove(THEME_IS_OPEN_CLASSNAME);
+    }
+  }
+
+  /* ========================================
+   * EVENT HANDLERS
+   * ======================================== */
+
+  /**
+   * Handles option selection from the dropdown.
+   * Creates a synthetic event for the parent's handleSelect method.
+   *
+   * @param {Event} event - Click or keydown event on option
+   */
+  handleOptionSelect(event) {
+    log.enter("handleOptionSelect", { type: event.type, key: event.key });
+
+    if (event.type === "keydown" && event.key !== "Enter") {
+      log.exit("handleOptionSelect", "ignored - not Enter key");
+      return;
+    }
+
+    event.preventDefault();
+
+    const index = parseInt(
+      event.currentTarget.getAttribute("data-option-index"),
+      10
+    );
+    const option = this.options[index];
+
+    log.debug("Place selected", {
+      index,
+      placeId: option?.place_id,
+      description: option?.description
+    });
+
+    if (option) {
+      // Create a synthetic event matching what the parent's handleSelect expects
+      const syntheticEvent = {
+        detail: {
+          item: option
+        },
+        stopPropagation: () => {}
+      };
+
+      // Call parent's handleSelect which handles Google Places details retrieval
+      try {
+        log.timeStart("placeDetailsRetrieval");
+        if (super.handleSelect) {
+          super.handleSelect(syntheticEvent);
+        }
+        log.debug("Place details request initiated");
+      } catch (error) {
+        log.error("Failed to retrieve place details", error);
+      }
+    }
+
+    this.hideOptionsDropdown();
+    log.exit("handleOptionSelect");
+  }
+
+  /**
+   * Handles mouse hover on options.
+   *
+   * @param {Event} event - Mouseover event
+   */
+  handleOptionFocus(event) {
+    const options = this.template.querySelectorAll('[role="option"]');
+    options.forEach((opt) => opt.classList.remove(THEME_HAS_FOCUS_CLASSNAME));
+
+    event.currentTarget.classList.add(THEME_HAS_FOCUS_CLASSNAME);
+    this._highlightIndex = parseInt(
+      event.currentTarget.getAttribute("data-option-index"),
+      10
+    );
+  }
+
+  /**
+   * Handles keyboard navigation.
+   *
+   * @param {KeyboardEvent} event - Keydown event on input
+   */
+  handleInputKeyDown(event) {
+    switch (event.key) {
+      case "Escape":
+        this.hideOptionsDropdown();
+        break;
+
+      case "ArrowDown":
+        event.preventDefault();
+        if (!this._showOptions && this.hasOptions) {
+          this.showOptionsDropdown();
+        }
+        this._highlightIndex = Math.min(
+          this._highlightIndex + 1,
+          this.options.length - 1
+        );
+        this.updateHighlight();
+        break;
+
+      case "ArrowUp":
+        event.preventDefault();
+        this._highlightIndex = Math.max(this._highlightIndex - 1, 0);
+        this.updateHighlight();
+        break;
+
+      case "Enter":
+        if (this._showOptions && this._highlightIndex >= 0) {
+          event.preventDefault();
+          const option = this.options[this._highlightIndex];
+          if (option) {
+            const syntheticEvent = {
+              detail: { item: option },
+              stopPropagation: () => {}
+            };
+            if (super.handleSelect) {
+              super.handleSelect(syntheticEvent);
+            }
+          }
+          this.hideOptionsDropdown();
+        }
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Updates visual highlight on options.
+   */
+  updateHighlight() {
+    const options = this.template.querySelectorAll('[role="option"]');
+    options.forEach((opt, idx) => {
+      if (idx === this._highlightIndex) {
+        opt.classList.add(THEME_HAS_FOCUS_CLASSNAME);
+        opt.scrollIntoView({ block: "nearest" });
+      } else {
+        opt.classList.remove(THEME_HAS_FOCUS_CLASSNAME);
+      }
+    });
+  }
+
+  /**
+   * Handles input changes and triggers Google Places search.
+   *
+   * @param {Event} event - Input event
+   */
+  handleInputChange() {
+    if (this.hasOptions) {
+      this.showOptionsDropdown();
+    }
+  }
+
+  /* ========================================
+   * LIFECYCLE METHODS
+   * ======================================== */
+
+  /**
+   * Returns the Ontario DS template.
+   *
+   * @returns {Object} Template to render
+   * @override
+   */
+  render() {
+    return tmpl;
+  }
+
+  /**
+   * Initializes component.
+   *
+   * @override
+   */
+  connectedCallback() {
+    log.enter("connectedCallback");
+    log.timeStart("initialization");
+
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    this._readOnlyClass = "sfgpsdscaon-read-only";
+    this._showOptions = false;
+    this._highlightIndex = -1;
+    this.classList.add("caon-scope");
+
+    log.debug("Component initialized", {
+      label: this._propSetMap?.label,
+      required: this._propSetMap?.required,
+      googleMapsAPIKey: this._propSetMap?.googleMapsAPIKey
+        ? "configured"
+        : "missing",
+      googleAddressCountry: this._propSetMap?.googleAddressCountry || "none"
+    });
+
+    log.timeEnd("initialization");
+    log.exit("connectedCallback");
+  }
+
+  /**
+   * Cleanup when component is removed.
+   *
+   * @override
+   */
+  disconnectedCallback() {
+    log.debug("Component disconnecting");
+
+    if (super.disconnectedCallback) {
+      super.disconnectedCallback();
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPlacesTypeahead/sfGpsDsCaOnFormPlacesTypeahead.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormPlacesTypeahead/sfGpsDsCaOnFormPlacesTypeahead.js-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>59.0</apiVersion>
+  <isExposed>false</isExposed>
+  <runtimeNamespace>omnistudio</runtimeNamespace>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRadio/sfGpsDsCaOnFormRadio.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRadio/sfGpsDsCaOnFormRadio.html
@@ -1,0 +1,86 @@
+<!-- sldsValidatorIgnore -->
+<template>
+  <div class="ontario-form-group">
+    <!-- LWR: Using dynamic legendId to avoid duplicate ID issues when multiple radio groups exist -->
+    <fieldset
+      class="ontario-fieldset"
+      role="radiogroup"
+      aria-required={required}
+      aria-labelledby={legendId}
+      aria-describedby={computedAriaDescribedBy}
+      aria-invalid={computedAriaInvalid}
+    >
+      <legend id={legendId} class="ontario-fieldset__legend">
+        <span class={computedLegendClassName}>
+          {label}
+          <span lwc:if={required} class="ontario-label__flag">(required)</span>
+          <span lwc:if={optional} class="ontario-label__flag">(optional)</span>
+        </span>
+        <slot name="label"> </slot>
+
+        <p lwc:if={fieldLevelHelp} id="helper" class="ontario-hint">
+          {fieldLevelHelp}
+        </p>
+
+        <div
+          lwc:if={sfGpsDsIsError}
+          class="ontario-error-messaging"
+          aria-live="assertive"
+          role="alert"
+          id="errorMessageBlock"
+        >
+          <svg
+            class="ontario-icon"
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+            />
+          </svg>
+          <span class="ontario-error-messaging__content"
+            >{sfGpsDsErrorMessage}</span
+          >
+        </div>
+      </legend>
+
+      <div class="ontario-radios">
+        <template
+          lwc:if={internalOpts}
+          for:each={internalOpts}
+          for:item="option"
+          for:index="index"
+        >
+          <div class="ontario-radios__item" key={option.id}>
+            <input
+              class="ontario-radios__input"
+              type="radio"
+              tabindex={tabIndex}
+              required={required}
+              disabled={computedDisabledOrReadOnly}
+              id={option.id}
+              name={option.name}
+              aria-invalid={computedAriaInvalid}
+              value={option.value}
+              checked={option.selected}
+              data-index={index}
+              data-omni-input
+              onfocus={handleFocus}
+              onblur={handleBlur}
+              onchange={sfGpsDsOnChangeValue}
+              onkeydown={handleKeyDownEvent}
+            />
+            <label
+              class="ontario-radios__label"
+              data-index={index}
+              for={option.id}
+            >
+              {option.label}
+            </label>
+          </div>
+        </template>
+      </div>
+    </fieldset>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRadio/sfGpsDsCaOnFormRadio.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRadio/sfGpsDsCaOnFormRadio.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { api } from "lwc";
+import OmnistudioRadioGroup from "c/sfGpsDsOmniRadioGroup";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormRadio.html";
+
+export default class SfGpsDsCaOnFormRadio extends OmnistudioRadioGroup {
+  @api readOnly;
+
+  /**
+   * Unique ID for this component instance.
+   * Used for aria-labelledby to avoid duplicate ID issues in Shadow DOM.
+   * @private
+   */
+  _uniqueId = `radio-${Math.random().toString(36).substring(2, 11)}`;
+
+  /* computed */
+
+  /**
+   * Dynamic legend ID to avoid duplicate IDs when multiple radio groups exist.
+   * LWR: Hardcoded IDs can cause duplicate ID issues in component instances.
+   * @returns {string} Unique legend element ID
+   */
+  get legendId() {
+    return `${this._uniqueId}-legend`;
+  }
+
+  get computedLegendClassName() {
+    return {
+      "ontario-fieldset__legend": true,
+      "ontario-fieldset__legend--required": this.required
+    };
+  }
+
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+
+  get computedAriaDescribedBy() {
+    return computeClass({
+      helper: this.fieldLevelHelp,
+      errorMessageBlock: this.sfGpsDsIsError
+    });
+  }
+
+  get computedDisabledOrReadOnly() {
+    return this.disabled || this.readOnly;
+  }
+
+  /* lifecycle */
+
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRadio/sfGpsDsCaOnFormRadio.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRadio/sfGpsDsCaOnFormRadio.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRange/sfGpsDsCaOnFormRange.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRange/sfGpsDsCaOnFormRange.css
@@ -1,0 +1,129 @@
+/* Ontario Design System - Range/Slider Styles */
+
+/* Range container with min/max labels */
+.ontario-range-container {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+/* Min/max value labels */
+.ontario-range__min-label,
+.ontario-range__max-label {
+  font-size: 0.875rem;
+  color: var(--ontario-colour-grey-dark, #4d4d4d);
+  flex-shrink: 0;
+  min-width: 2.5rem;
+  text-align: center;
+}
+
+/* Base range input styling */
+.ontario-range {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 8px;
+  border-radius: 4px;
+  background: var(--ontario-colour-grey-light, #ccc);
+  outline: none;
+  cursor: pointer;
+}
+
+/* Range track for WebKit browsers */
+.ontario-range::-webkit-slider-runnable-track {
+  height: 8px;
+  border-radius: 4px;
+  background: var(--ontario-colour-grey-light, #ccc);
+}
+
+/* Range thumb for WebKit browsers */
+.ontario-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--ontario-colour-primary, #1a1a1a);
+  cursor: pointer;
+  margin-top: -8px;
+  border: 2px solid var(--ontario-colour-white, #fff);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.15s ease;
+}
+
+.ontario-range::-webkit-slider-thumb:hover {
+  transform: scale(1.1);
+}
+
+/* Range track for Firefox */
+.ontario-range::-moz-range-track {
+  height: 8px;
+  border-radius: 4px;
+  background: var(--ontario-colour-grey-light, #ccc);
+}
+
+/* Range thumb for Firefox */
+.ontario-range::-moz-range-thumb {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--ontario-colour-primary, #1a1a1a);
+  cursor: pointer;
+  border: 2px solid var(--ontario-colour-white, #fff);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.15s ease;
+}
+
+.ontario-range::-moz-range-thumb:hover {
+  transform: scale(1.1);
+}
+
+/* Focus state - WCAG 2.4.7 Focus Visible */
+/* Note: We use box-shadow on thumb as visible focus indicator */
+/* The outline:none is acceptable because we provide an alternative visible focus */
+.ontario-range:focus {
+  outline: 2px solid transparent; /* For high contrast mode */
+}
+
+.ontario-range:focus-visible {
+  /* ODS-compliant focus ring on the track - 4px for visibility */
+  outline: 4px solid var(--ontario-colour-focus, #009adb);
+  outline-offset: 2px;
+}
+
+.ontario-range:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 4px var(--ontario-colour-focus, #009acd);
+  transform: scale(1.1);
+}
+
+.ontario-range:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 4px var(--ontario-colour-focus, #009acd);
+  transform: scale(1.1);
+}
+
+/* Disabled state */
+.ontario-range:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ontario-range:disabled::-webkit-slider-thumb {
+  cursor: not-allowed;
+}
+
+.ontario-range:disabled::-moz-range-thumb {
+  cursor: not-allowed;
+}
+
+/* Current value display */
+.ontario-range__value-display {
+  margin-top: 0.75rem;
+  font-size: 0.875rem;
+  color: var(--ontario-colour-grey-dark, #4d4d4d);
+}
+
+.ontario-range__current-value strong {
+  font-weight: 700;
+  color: var(--ontario-colour-black, #1a1a1a);
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRange/sfGpsDsCaOnFormRange.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRange/sfGpsDsCaOnFormRange.html
@@ -1,0 +1,111 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System - Range/Slider Input for OmniStudio
+  
+  This template renders a range slider with Ontario DS styling.
+  
+  Compliance:
+  - LWR: Compatible (uses Light DOM parent)
+  - LWS: Compatible (no restricted APIs)
+  - Ontario DS: Custom slider styling with Ontario colors
+  - WCAG 2.1 AA: 
+    - Label associated with input via for/id
+    - Hint text via aria-describedby
+    - Error messages with role="alert"
+    - Keyboard accessible (arrow keys, tab)
+    - Current value announced to screen readers
+
+  Template Bindings:
+  - inputId: Unique ID for the input element
+  - mergedLabel: From getter (supports merge fields)
+  - required/disabled: From _propSetMap configuration
+  - min/max/step: From _propSetMap range configuration
+  - value: From elementValue (current slider value)
+  - displayValue: Formatted display of current value
+  - minValue/maxValue: Range bounds for display
+  
+  Event Handlers:
+  - onchange: handleRangeChange - Updates OmniScript data model
+  - oninput: handleRangeInput - Real-time value display update
+-->
+<template>
+  <div class="ontario-form-group">
+    <!-- Label -->
+    <label class="ontario-label" for={inputId}>
+      {mergedLabel}
+      <span lwc:if={_propSetMap.required} class="ontario-label__flag"
+        >(required)</span
+      >
+      <span lwc:if={_propSetMap.optional} class="ontario-label__flag"
+        >(optional)</span
+      >
+    </label>
+
+    <!-- Hint text -->
+    <p lwc:if={mergedHelpText} class="ontario-hint" id="hint-{inputId}">
+      {mergedHelpText}
+    </p>
+
+    <!-- Error message -->
+    <div
+      lwc:if={sfGpsDsIsError}
+      class="ontario-error-messaging"
+      id="error-{inputId}"
+      role="alert"
+    >
+      <span class="ontario-error-messaging__icon">
+        <svg class="ontario-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+          />
+        </svg>
+      </span>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <!-- Range slider container -->
+    <div class="ontario-range-container">
+      <!-- Min value label -->
+      <span class="ontario-range__min-label" aria-hidden="true"
+        >{minValue}</span
+      >
+
+      <!-- Range input -->
+      <!-- WCAG: aria-valuenow/min/max for screen readers, aria-required for required fields -->
+      <input
+        type="range"
+        id={inputId}
+        class="ontario-range"
+        name={_name}
+        value={displayValue}
+        min={minValue}
+        max={maxValue}
+        step={stepValue}
+        disabled={_propSetMap.disabled}
+        aria-required={_propSetMap.required}
+        aria-describedby={computedAriaDescribedBy}
+        aria-valuenow={displayValue}
+        aria-valuemin={minValue}
+        aria-valuemax={maxValue}
+        aria-valuetext={computedAriaValueText}
+        data-omni-input
+        onchange={handleRangeChange}
+        oninput={handleRangeInput}
+      />
+
+      <!-- Max value label -->
+      <span class="ontario-range__max-label" aria-hidden="true"
+        >{maxValue}</span
+      >
+    </div>
+
+    <!-- Current value display -->
+    <div class="ontario-range__value-display" aria-live="polite">
+      <span class="ontario-range__current-value"
+        >Current value: <strong>{displayValue}</strong></span
+      >
+    </div>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRange/sfGpsDsCaOnFormRange.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRange/sfGpsDsCaOnFormRange.js
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import OmniscriptRange from "c/sfGpsDsOsrtOmniscriptRange";
+import SfGpsDsOmniHasValidationMixin from "c/sfGpsDsOmniHasValidationMixin";
+import { omniGetMergedField } from "c/sfGpsDsOmniHelpers";
+import tmpl from "./sfGpsDsCaOnFormRange.html";
+
+/**
+ * @slot Range
+ * @description Ontario Design System Range/Slider input for OmniStudio forms.
+ * Extends the base OmniScript Range with Ontario DS styling and validation.
+ *
+ * This component overrides the standard OmniScript Range element to provide
+ * Ontario Design System styling while maintaining full slider functionality.
+ *
+ * ## Architecture
+ * - Extends: SfGpsDsOmniHasValidationMixin(OmniscriptRange)
+ * - Input Type: HTML range input styled with Ontario DS
+ * - Validation: Min/max range bounds, step validation
+ *
+ * ## OmniScript Configuration
+ * In OmniScript Designer, configure the Range:
+ * - Range Low: Minimum value
+ * - Range High: Maximum value
+ * - Step: Increment step size
+ * - Default Value: Initial slider position
+ *
+ * ## Inherited Properties (from OmniScript)
+ * - _propSetMap.rangeLow: Minimum value
+ * - _propSetMap.rangeHigh: Maximum value
+ * - _propSetMap.step: Step increment
+ * - elementValue: Current slider value
+ *
+ * ## OmniScript Registration
+ * Register in your OmniScript LWC override:
+ * ```javascript
+ * import sfGpsDsCaOnFormRange from "c/sfGpsDsCaOnFormRange";
+ *
+ * static elementTypeToLwcConstructorMap = {
+ *   ...OmniscriptBaseOsrt.elementTypeToLwcConstructorMap,
+ *   "Range": sfGpsDsCaOnFormRange,
+ * };
+ * ```
+ *
+ * Compliance:
+ * - LWR: Uses Light DOM parent component
+ * - LWS: No eval(), proper namespace imports
+ * - Ontario DS: Custom slider styling with Ontario colors
+ * - WCAG 2.1 AA: Proper labeling, keyboard accessible, aria attributes
+ */
+export default class SfGpsDsCaOnFormRange extends SfGpsDsOmniHasValidationMixin(
+  OmniscriptRange
+) {
+  /* ========================================
+   * COMPUTED PROPERTIES
+   * ======================================== */
+
+  /**
+   * Gets the merged label with any merge field values replaced.
+   * @returns {string} The resolved label text
+   */
+  get mergedLabel() {
+    return omniGetMergedField(this, this._propSetMap.label);
+  }
+
+  /**
+   * Gets the merged help text with any merge field values replaced.
+   * @returns {string} The resolved help text
+   */
+  get mergedHelpText() {
+    return omniGetMergedField(this, this._handleHelpText);
+  }
+
+  /**
+   * Gets the minimum value for the range.
+   * @returns {number} The minimum value
+   */
+  get minValue() {
+    return this._propSetMap.rangeLow || 0;
+  }
+
+  /**
+   * Gets the maximum value for the range.
+   * @returns {number} The maximum value
+   */
+  get maxValue() {
+    return this._propSetMap.rangeHigh || 100;
+  }
+
+  /**
+   * Gets the step value for the range.
+   * @returns {number} The step increment
+   */
+  get stepValue() {
+    return this._propSetMap.step || 1;
+  }
+
+  /**
+   * Computes the unique ID for the input element.
+   * @returns {string} The input ID
+   */
+  get inputId() {
+    return `range-${this._name}`;
+  }
+
+  /**
+   * Computes the percentage position for the value indicator.
+   * @returns {number} The percentage (0-100)
+   */
+  get valuePercentage() {
+    const value = this.elementValue || this.minValue;
+    const range = this.maxValue - this.minValue;
+    if (range === 0) return 0;
+    return ((value - this.minValue) / range) * 100;
+  }
+
+  /**
+   * Gets the current display value.
+   * @returns {number|string} The current value or min value if not set
+   */
+  get displayValue() {
+    return this.elementValue != null ? this.elementValue : this.minValue;
+  }
+
+  /**
+   * Computes a descriptive value text for screen readers.
+   * AODA/WCAG: Provides context for the current value (e.g., "50 out of 100").
+   * @returns {string} Descriptive value text
+   */
+  get computedAriaValueText() {
+    const value = this.displayValue;
+    const max = this.maxValue;
+    return `${value} out of ${max}`;
+  }
+
+  /**
+   * Computes the aria-describedby attribute value.
+   * References hint text and error message elements when present.
+   * @returns {string|null} Space-separated IDs or null
+   */
+  get computedAriaDescribedBy() {
+    const ids = [];
+    if (this.mergedHelpText) {
+      ids.push(`hint-${this.inputId}`);
+    }
+    if (this.sfGpsDsIsError) {
+      ids.push(`error-${this.inputId}`);
+    }
+    return ids.length > 0 ? ids.join(" ") : null;
+  }
+
+  /**
+   * Computes the accessible label for the range input.
+   * Includes current value for screen reader users.
+   * @returns {string} The accessible label
+   */
+  get computedAriaLabel() {
+    return `${this.mergedLabel}, slider, current value ${this.displayValue}, minimum ${this.minValue}, maximum ${this.maxValue}`;
+  }
+
+  /* ========================================
+   * LIFECYCLE METHODS
+   * ======================================== */
+
+  /**
+   * Renders the Ontario-specific template.
+   * @returns {Object} The imported HTML template
+   */
+  render() {
+    return tmpl;
+  }
+
+  /**
+   * Initializes the component when added to DOM.
+   * Sets up Ontario DS-specific styling classes.
+   */
+  connectedCallback() {
+    super.connectedCallback();
+
+    // Set read-only styling class for Ontario DS
+    this._readOnlyClass = "sfgpsdscaon-read-only";
+
+    // Add Ontario DS scope class for CSS isolation
+    this.classList.add("caon-scope");
+  }
+
+  /* ========================================
+   * EVENT HANDLERS
+   * ======================================== */
+
+  /**
+   * Handles range input changes.
+   * Updates OmniScript data and triggers validation.
+   * @param {Event} event - The input change event
+   */
+  handleRangeChange(event) {
+    const value = parseFloat(event.target.value);
+    this.applyCallResp(value);
+  }
+
+  /**
+   * Handles range input for real-time value display.
+   * @param {Event} event - The input event
+   */
+  handleRangeInput(event) {
+    // Force re-render for value display
+    // eslint-disable-next-line no-self-assign
+    this.elementValue = parseFloat(event.target.value);
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRange/sfGpsDsCaOnFormRange.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormRange/sfGpsDsCaOnFormRange.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Range/Slider input for OmniStudio standard runtime forms. LWR and LWS compatible. WCAG 2.1 AA compliant. Provides slider input with min/max bounds.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelect/sfGpsDsCaOnFormSelect.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelect/sfGpsDsCaOnFormSelect.css
@@ -1,0 +1,164 @@
+/*
+ * Ontario Design System Select/Dropdown styles for OmniStudio forms.
+ * Shadow DOM scoped styles.
+ */
+
+/* Form group container */
+.ontario-form-group {
+  margin-bottom: 1.5rem;
+}
+
+/* Label styling */
+.ontario-label {
+  display: block;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+}
+
+.ontario-label__flag {
+  font-weight: 400;
+  font-style: normal;
+}
+
+/* Hint text */
+.ontario-hint {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+
+/* HTML hint content support - lists */
+.ontario-hint ul,
+.ontario-hint ol {
+  margin: 0.5rem 0;
+  padding-left: 1.5rem;
+}
+
+.ontario-hint li {
+  margin-bottom: 0.25rem;
+  line-height: 1.5;
+}
+
+.ontario-hint li:last-child {
+  margin-bottom: 0;
+}
+
+/* Nested list styling */
+.ontario-hint ul ul,
+.ontario-hint ol ol,
+.ontario-hint ul ol,
+.ontario-hint ol ul {
+  margin-top: 0.25rem;
+  margin-bottom: 0;
+}
+
+/* HTML hint content support - links */
+.ontario-hint a {
+  color: #0066cc;
+  text-decoration: underline;
+}
+
+.ontario-hint a:hover {
+  color: #00478f;
+}
+
+.ontario-hint a:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 2px;
+}
+
+.ontario-hint a:visited {
+  color: #551a8b;
+}
+
+/* HTML hint content support - paragraphs */
+.ontario-hint p {
+  margin: 0 0 0.5rem 0;
+}
+
+.ontario-hint p:last-child {
+  margin-bottom: 0;
+}
+
+/* Dropdown container - positions the arrow icon */
+.ontario-dropdown__container {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+  max-width: 48rem;
+}
+
+/* Select/dropdown input */
+.ontario-input.ontario-dropdown {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  width: 100%;
+  padding: 0.625rem 3rem 0.625rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background-color: #ffffff;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.ontario-input.ontario-dropdown:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 0;
+  box-shadow: 0 0 0 4px #009ade;
+}
+
+.ontario-input.ontario-dropdown:disabled {
+  background-color: #e6e6e6;
+  border-color: #666666;
+  color: #666666;
+  cursor: not-allowed;
+}
+
+/* Dropdown arrow icon */
+.ontario-dropdown__icon {
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  pointer-events: none;
+  fill: #1a1a1a;
+}
+
+.ontario-input.ontario-dropdown:disabled + .ontario-dropdown__icon {
+  fill: #666666;
+}
+
+/* Error styling */
+.ontario-input__error {
+  border-color: #cd0000;
+}
+
+.ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #cd0000;
+  margin-bottom: 0.5rem;
+}
+
+.ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  fill: #cd0000;
+}
+
+.ontario-error-messaging__content {
+  font-size: 1rem;
+  line-height: 1.5;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelect/sfGpsDsCaOnFormSelect.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelect/sfGpsDsCaOnFormSelect.html
@@ -1,0 +1,95 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System Select/Dropdown for OmniStudio forms.
+  Renders inline (Shadow DOM) without Light DOM child components.
+  
+  Compliance:
+  - LWR: Shadow DOM compatible (uses lwc:dom="manual" for dynamic HTML)
+  - LWS: Compatible (uses replaceInnerHtml helper)
+  - Ontario DS: Uses ontario-dropdown styling
+  - WCAG 2.1 AA / AODA: Focus management, aria attributes, aria-describedby links hint to input
+  
+  HTML Hint Support:
+  - The hint text area supports rich HTML content (lists, links, etc.)
+  - Content is injected via lwc:dom="manual" in renderedCallback
+  - Merge fields in help text are resolved before rendering
+-->
+<template>
+  <div class="ontario-form-group">
+    <!-- Label -->
+    <label class="ontario-label" for={inputId}>
+      {mergedLabel}
+      <span lwc:if={showRequiredFlag} class="ontario-label__flag"
+        >(required)</span
+      >
+      <span lwc:if={showOptionalFlag} class="ontario-label__flag"
+        >(optional)</span
+      >
+    </label>
+
+    <!-- Hint text (supports HTML content via lwc:dom="manual") -->
+    <div
+      lwc:if={mergedHelpText}
+      id={hintId}
+      class="ontario-hint sfGpsDsCaOnHint"
+      lwc:dom="manual"
+    ></div>
+
+    <!-- Error message -->
+    <div
+      lwc:if={sfGpsDsIsError}
+      id={errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <!-- Dropdown container -->
+    <div class="ontario-dropdown__container">
+      <select
+        id={inputId}
+        name={_name}
+        class={computedSelectClassName}
+        disabled={_propSetMap.disabled}
+        required={_propSetMap.required}
+        aria-required={computedAriaRequired}
+        aria-describedby={computedAriaDescribedBy}
+        aria-invalid={computedAriaInvalid}
+        data-omni-input
+        onchange={handleChange}
+        onblur={handleBlur}
+      >
+        <option value="">{defaultOptionLabel}</option>
+        <template for:each={decoratedOptions} for:item="opt">
+          <option key={opt.value} value={opt.value} selected={opt.selected}>
+            {opt.label}
+          </option>
+        </template>
+      </select>
+
+      <!-- Dropdown arrow icon -->
+      <svg
+        class="ontario-dropdown__icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
+      </svg>
+    </div>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelect/sfGpsDsCaOnFormSelect.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelect/sfGpsDsCaOnFormSelect.js
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import SfGpsDsFormSelect from "c/sfGpsDsFormSelect";
+import { omniGetMergedField } from "c/sfGpsDsOmniHelpers";
+import { computeClass, replaceInnerHtml } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormSelect.html";
+
+/**
+ * @slot Select
+ * @description Ontario Design System Select/Dropdown component for OmniStudio forms.
+ * Renders inline (Shadow DOM) - does not use Light DOM child components.
+ *
+ * ## HTML Hint Support
+ * The help text field supports rich HTML content including:
+ * - Bullet lists (`<ul>`, `<li>`)
+ * - Links (`<a href="...">`)
+ * - Text formatting (`<strong>`, `<em>`)
+ * - Paragraphs (`<p>`)
+ *
+ * Configure in OmniScript Designer:
+ * - Set the "Help Text" field with HTML markup
+ * - Merge fields (e.g., %FieldName%) are supported within the HTML
+ *
+ * Compliance:
+ * - LWR: Compatible (uses lwc:dom="manual" for dynamic HTML)
+ * - LWS: Compatible (uses replaceInnerHtml helper)
+ * - Ontario DS: Uses ontario-dropdown styling
+ * - WCAG 2.1 AA / AODA: Focus management, aria-describedby links hint to input
+ */
+export default class SfGpsDsCaOnFormSelect extends SfGpsDsFormSelect {
+  /* ========================================
+   * CONSTANTS
+   * ======================================== */
+
+  /**
+   * CSS selector for the hint container element.
+   * Used to locate the element for HTML injection.
+   * @type {string}
+   */
+  static HINT_QUERY_SELECTOR = ".sfGpsDsCaOnHint";
+  /**
+   * Unique ID for this component instance.
+   * Used for element IDs to avoid duplicates in Shadow DOM.
+   * @private
+   */
+  _uniqueId = `select-${Math.random().toString(36).substring(2, 11)}`;
+
+  /* ========================================
+   * COMPUTED PROPERTIES
+   * ======================================== */
+
+  get inputId() {
+    return `${this._uniqueId}-input`;
+  }
+
+  get hintId() {
+    return `${this._uniqueId}-hint`;
+  }
+
+  get errorId() {
+    return `${this._uniqueId}-error`;
+  }
+
+  get showRequiredFlag() {
+    return this._propSetMap?.required === true;
+  }
+
+  get showOptionalFlag() {
+    return this._propSetMap?.optional === true && !this._propSetMap?.required;
+  }
+
+  get defaultOptionLabel() {
+    return this._defaultLabel || "Select";
+  }
+
+  get computedSelectClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "ontario-dropdown": true,
+      "ontario-input__error": this.sfGpsDsIsError
+    });
+  }
+
+  get computedAriaDescribedBy() {
+    return computeClass({
+      [this.hintId]: this.mergedHelpText,
+      [this.errorId]: this.sfGpsDsIsError
+    });
+  }
+
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+
+  get computedAriaRequired() {
+    return this._propSetMap?.required ? "true" : "false";
+  }
+
+  /**
+   * Decorate options with selected state based on current value.
+   * Uses _realtimeOptions which is populated by the OmniScript runtime.
+   */
+  get decoratedOptions() {
+    if (!this._realtimeOptions || !Array.isArray(this._realtimeOptions)) {
+      return [];
+    }
+    return this._realtimeOptions.map((opt) => ({
+      ...opt,
+      // Use 'name' as the value identifier (OmniScript convention)
+      value: opt.name || opt.value,
+      // Use 'value' as the display label (OmniScript convention)
+      label: opt.value || opt.label || opt.name,
+      selected: (opt.name || opt.value) === this.elementValue
+    }));
+  }
+
+  /* ========================================
+   * EVENT HANDLERS
+   * ======================================== */
+
+  /**
+   * Handles change events from the native select element.
+   * Updates the OmniScript data with the selected value.
+   * @param {Event} event - The change event from the select element
+   */
+  handleChange(event) {
+    const selectedValue = event.target.value;
+    this.applyCallResp(selectedValue);
+  }
+
+  /**
+   * Handles blur events from the native select element.
+   * Triggers validation when the field loses focus.
+   * @param {Event} event - The blur event from the select element
+   */
+  handleBlur() {
+    this.reportValidity();
+  }
+
+  /* ========================================
+   * LIFECYCLE
+   * ======================================== */
+
+  /**
+   * Initialize component variables.
+   * Sets the input selector for the parent validation framework.
+   */
+  initCompVariables() {
+    super.initCompVariables();
+    // Set the selector so the parent class can find our native select element
+    // This is used by the validation framework to get childInput
+    this._inputSelector = "select[data-omni-input]";
+  }
+
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+    this.classList.add("caon-scope");
+  }
+
+  /**
+   * Called after each render to inject HTML hint content.
+   * Uses replaceInnerHtml for LWS-compatible DOM manipulation.
+   */
+  renderedCallback() {
+    if (super.renderedCallback) {
+      super.renderedCallback();
+    }
+
+    const hintElement = this.template.querySelector(
+      SfGpsDsCaOnFormSelect.HINT_QUERY_SELECTOR
+    );
+
+    if (hintElement && this.mergedHelpText) {
+      // Get help text with merge fields resolved
+      const mergedContent = omniGetMergedField(this, this._handleHelpText);
+
+      // Safely inject the HTML content
+      replaceInnerHtml(hintElement, mergedContent);
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelect/sfGpsDsCaOnFormSelect.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelect/sfGpsDsCaOnFormSelect.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelectableCards/sfGpsDsCaOnFormSelectableCards.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelectableCards/sfGpsDsCaOnFormSelectableCards.css
@@ -1,0 +1,196 @@
+/* Ontario Design System Selectable Cards for OmniStudio */
+
+.ontario-fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0 0 1.5rem 0;
+  min-width: 0;
+}
+.ontario-fieldset__legend {
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+  padding: 0;
+  display: block;
+}
+.ontario-label__flag {
+  font-weight: 400;
+}
+.ontario-hint {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+.ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #cd0000;
+  margin-bottom: 0.5rem;
+}
+.ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  fill: #cd0000;
+}
+.ontario-error-messaging__content {
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+/* Card group */
+.sfgpsdscaon-selectable-card-group__cards {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Individual card */
+.sfgpsdscaon-selectable-card {
+  border: 2px solid #1a1a1a;
+  border-radius: 8px;
+  padding: 1rem;
+  background: #fff;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+}
+.sfgpsdscaon-selectable-card--checked {
+  border-color: #1a1a1a;
+  background: #f9f9f9;
+  box-shadow: inset 0 0 0 2px #1a1a1a;
+}
+
+/* Card header with checkbox */
+.sfgpsdscaon-selectable-card__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+.sfgpsdscaon-selectable-card__checkbox {
+  position: relative;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin: 0;
+  cursor: pointer;
+  accent-color: #1a1a1a;
+  flex-shrink: 0;
+}
+.sfgpsdscaon-selectable-card__checkbox:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 2px;
+}
+.sfgpsdscaon-selectable-card__checkbox:disabled {
+  cursor: not-allowed;
+}
+
+/* Label and title */
+.sfgpsdscaon-selectable-card__label {
+  flex: 1;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+}
+.sfgpsdscaon-selectable-card__title-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.sfgpsdscaon-selectable-card__title {
+  font-weight: 600;
+}
+
+/* Badge */
+.sfgpsdscaon-selectable-card__badge {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  border-radius: 4px;
+}
+.sfgpsdscaon-selectable-card__badge--info {
+  background: #e0f0ff;
+  color: #0066cc;
+}
+.sfgpsdscaon-selectable-card__badge--success {
+  background: #e6f4ea;
+  color: #1e7e34;
+}
+.sfgpsdscaon-selectable-card__badge--warning {
+  background: #fff4e6;
+  color: #b85c00;
+}
+.sfgpsdscaon-selectable-card__badge--error {
+  background: #fde7e7;
+  color: #cd0000;
+}
+
+/* Description */
+.sfgpsdscaon-selectable-card__description {
+  margin-top: 0.5rem;
+  margin-left: 2.25rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+}
+
+/* Link */
+.sfgpsdscaon-selectable-card__link {
+  display: inline-block;
+  margin-top: 0.5rem;
+  margin-left: 2.25rem;
+  color: #0066cc;
+  text-decoration: underline;
+}
+.sfgpsdscaon-selectable-card__link:hover {
+  text-decoration: none;
+}
+
+/* Expand button */
+.sfgpsdscaon-selectable-card__expand-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.75rem;
+  margin-left: 2.25rem;
+  padding: 0.25rem 0;
+  background: none;
+  border: none;
+  color: #0066cc;
+  font-size: 1rem;
+  cursor: pointer;
+  text-decoration: underline;
+}
+.sfgpsdscaon-selectable-card__expand-btn:hover {
+  text-decoration: none;
+}
+.sfgpsdscaon-selectable-card__expand-btn:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 2px;
+}
+.sfgpsdscaon-selectable-card__expand-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: currentColor;
+}
+
+/* Expanded content */
+.sfgpsdscaon-selectable-card__expanded-content {
+  margin-top: 0.75rem;
+  margin-left: 2.25rem;
+  padding: 1rem;
+  background: #f5f5f5;
+  border-radius: 4px;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelectableCards/sfGpsDsCaOnFormSelectableCards.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelectableCards/sfGpsDsCaOnFormSelectableCards.html
@@ -1,0 +1,130 @@
+<!-- sldsValidatorIgnore -->
+<template>
+  <fieldset
+    class={computedFieldsetClassName}
+    aria-describedby={computedAriaDescribedBy}
+    aria-invalid={computedAriaInvalid}
+    aria-required={computedAriaRequired}
+  >
+    <legend class="ontario-fieldset__legend">
+      {mergedLabel}
+      <span lwc:if={showRequiredFlag} class="ontario-label__flag"
+        >(required)</span
+      >
+      <span lwc:if={showOptionalFlag} class="ontario-label__flag"
+        >(optional)</span
+      >
+    </legend>
+
+    <p lwc:if={mergedHelpText} id={hintId} class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <div
+      lwc:if={sfGpsDsIsError}
+      id={errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <div class="sfgpsdscaon-selectable-card-group__cards">
+      <template for:each={inlineDecoratedOptions} for:item="opt">
+        <div key={opt.key} class={opt.cardClassName}>
+          <!-- Checkbox and Label -->
+          <div class="sfgpsdscaon-selectable-card__header">
+            <input
+              type="checkbox"
+              class="sfgpsdscaon-selectable-card__checkbox"
+              id={opt.id}
+              name={_name}
+              value={opt.value}
+              checked={opt.checked}
+              disabled={_propSetMap.readOnly}
+              data-omni-input
+              data-index={opt.index}
+              onchange={handleCardCheckboxChange}
+              onblur={handleBlur}
+            />
+            <label class="sfgpsdscaon-selectable-card__label" for={opt.id}>
+              <span class="sfgpsdscaon-selectable-card__title-wrapper">
+                <span class="sfgpsdscaon-selectable-card__title"
+                  >{opt.label}</span
+                >
+                <span lwc:if={opt.badge} class={opt.badgeClassName}
+                  >{opt.badge}</span
+                >
+              </span>
+            </label>
+          </div>
+
+          <!-- Description -->
+          <div
+            lwc:if={opt.description}
+            class="sfgpsdscaon-selectable-card__description"
+          >
+            {opt.description}
+          </div>
+
+          <!-- Optional Link -->
+          <a
+            lwc:if={opt.linkLabel}
+            href={opt.linkUrl}
+            class="sfgpsdscaon-selectable-card__link"
+          >
+            {opt.linkLabel}
+          </a>
+
+          <!-- View More Button -->
+          <button
+            lwc:if={opt.expandedContent}
+            type="button"
+            class="sfgpsdscaon-selectable-card__expand-btn"
+            aria-expanded={opt.isExpanded}
+            data-index={opt.index}
+            onclick={handleExpandClick}
+          >
+            <svg
+              class="sfgpsdscaon-selectable-card__expand-icon"
+              aria-hidden="true"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                lwc:if={opt.isExpanded}
+                d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"
+              ></path>
+              <path
+                lwc:else
+                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              ></path>
+            </svg>
+            {opt.expandButtonLabel}
+          </button>
+
+          <!-- Expanded Content -->
+          <div
+            lwc:if={opt.isExpanded}
+            class="sfgpsdscaon-selectable-card__expanded-content"
+          >
+            {opt.expandedContent}
+          </div>
+        </div>
+      </template>
+    </div>
+  </fieldset>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelectableCards/sfGpsDsCaOnFormSelectableCards.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelectableCards/sfGpsDsCaOnFormSelectableCards.js
@@ -1,0 +1,363 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import { api, track } from "lwc";
+import SfGpsDsFormMultiselect from "c/sfGpsDsFormMultiselect";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormSelectableCards.html";
+
+const DEBUG = false;
+const CLASS_NAME = "SfGpsDsCaOnFormSelectableCards";
+
+export default class SfGpsDsCaOnFormSelectableCards extends SfGpsDsFormMultiselect {
+  _uniqueId = `selectable-cards-${Math.random().toString(36).substring(2, 11)}`;
+
+  // Flag to track when we're in the middle of applying a value
+  // This allows us to return true from validation during value updates
+  _isApplyingValue = false;
+
+  // Tracked properties for error display (triggers reactivity)
+  @track isError = false;
+  @track errorMessage = "";
+
+  @api configRequired;
+  @api configErrorMessage;
+  @api configOptionsJson;
+
+  @track _expandedIndices = {};
+
+  /* IDs */
+  get hintId() {
+    return `${this._uniqueId}-hint`;
+  }
+  get errorId() {
+    return `${this._uniqueId}-error`;
+  }
+
+  /* Computed properties */
+  get showRequiredFlag() {
+    return this._propSetMap?.required === true;
+  }
+  get showOptionalFlag() {
+    return this._propSetMap?.optional === true && !this._propSetMap?.required;
+  }
+  get computedAriaRequired() {
+    return this._propSetMap?.required ? "true" : "false";
+  }
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+
+  /**
+   * Returns true if the component is in an error state.
+   * Used by the template to show/hide the error container.
+   */
+  get sfGpsDsIsError() {
+    return this.isError || this._sfGpsDsCustomValidation;
+  }
+
+  /**
+   * Returns the error message to display.
+   * Used by the template for the error message content.
+   */
+  get sfGpsDsErrorMessage() {
+    return this._sfGpsDsCustomValidation || this.errorMessage;
+  }
+
+  get computedAriaDescribedBy() {
+    return computeClass({
+      [this.hintId]: this.mergedHelpText,
+      [this.errorId]: this.sfGpsDsIsError
+    });
+  }
+
+  get computedFieldsetClassName() {
+    return computeClass({
+      "ontario-fieldset": true,
+      "sfgpsdscaon-selectable-card-group": true,
+      "sfgpsdscaon-selectable-card-group--error": this.sfGpsDsIsError
+    });
+  }
+
+  get inlineDecoratedOptions() {
+    const selected = this._selectedValues;
+
+    // Get extended options from configOptionsJson or nested propSetMap
+    const nestedPropSetMap = this.jsonDef?.propSetMap?.propSetMap;
+    const extendedOptionsJson =
+      this.configOptionsJson || nestedPropSetMap?.optionsJson;
+    let extendedOptions = {};
+
+    if (extendedOptionsJson) {
+      try {
+        const parsed =
+          typeof extendedOptionsJson === "string"
+            ? JSON.parse(extendedOptionsJson)
+            : extendedOptionsJson;
+        if (Array.isArray(parsed)) {
+          parsed.forEach((opt) => {
+            extendedOptions[opt.value] = opt;
+          });
+        }
+      } catch (e) {
+        console.error("Error parsing optionsJson", e);
+      }
+    }
+
+    return (this._realtimeOptions || []).map((opt, index) => {
+      const optValue = opt.value || opt.name || opt.label;
+      const optLabel = opt.label || opt.value || opt.name;
+      const extended = extendedOptions[optValue] || {};
+      const isChecked = selected.includes(optValue);
+      const isExpanded = this._expandedIndices[index] || false;
+
+      return {
+        value: optValue,
+        label: extended.label || optLabel,
+        description: extended.description || "",
+        linkLabel: extended.linkLabel || "",
+        linkUrl: extended.linkUrl || "",
+        badge: extended.badge || "",
+        badgeVariant: extended.badgeVariant || "info",
+        expandedContent: extended.expandedContent || "",
+        checked: isChecked,
+        isExpanded: isExpanded,
+        expandButtonLabel: isExpanded ? "View less" : "View more",
+        key: `opt-${index}-${optValue}`,
+        id: `${this._uniqueId}-opt-${index}`,
+        index: index,
+        cardClassName: computeClass({
+          "sfgpsdscaon-selectable-card": true,
+          "sfgpsdscaon-selectable-card--checked": isChecked
+        }),
+        badgeClassName: computeClass({
+          "sfgpsdscaon-selectable-card__badge": true,
+          [`sfgpsdscaon-selectable-card__badge--${extended.badgeVariant || "info"}`]: true
+        })
+      };
+    });
+  }
+
+  /**
+   * Parses elementValue which can be a semicolon-delimited string or array.
+   * @returns {string[]} Array of selected values
+   */
+  get _selectedValues() {
+    if (!this.elementValue) return [];
+    if (Array.isArray(this.elementValue)) return this.elementValue;
+    if (typeof this.elementValue === "string") {
+      return this.elementValue.split(";").filter((v) => v);
+    }
+    return [this.elementValue.toString()];
+  }
+
+  /* Event handlers */
+  handleCardCheckboxChange(event) {
+    if (DEBUG) console.log(CLASS_NAME, "handleCardCheckboxChange called");
+
+    const checkbox = event.target;
+    const value = checkbox.value;
+    const checked = checkbox.checked;
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "  checkbox value:", value);
+      console.log(CLASS_NAME, "  checkbox checked:", checked);
+    }
+
+    // Get current selected values as array
+    let currentValues = [...this._selectedValues];
+
+    if (checked) {
+      if (!currentValues.includes(value)) {
+        currentValues.push(value);
+      }
+    } else {
+      currentValues = currentValues.filter((v) => v !== value);
+    }
+
+    // OmniScript expects semicolon-delimited string for multiselect values
+    const valueString = currentValues.join(";");
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "  valueString to apply:", valueString);
+    }
+
+    // Set flag to allow value to be applied without validation blocking it
+    this._isApplyingValue = true;
+
+    this.applyCallResp(valueString);
+
+    // Clear the flag
+    this._isApplyingValue = false;
+
+    if (DEBUG) {
+      console.log(
+        CLASS_NAME,
+        "  elementValue after applyCallResp:",
+        this.elementValue
+      );
+    }
+  }
+
+  /**
+   * Handles blur events from card checkboxes.
+   * Triggers validation when focus leaves.
+   */
+  handleBlur() {
+    this.reportValidity();
+  }
+
+  handleExpandClick(event) {
+    const index = parseInt(event.currentTarget.dataset.index, 10);
+    this._expandedIndices = {
+      ...this._expandedIndices,
+      [index]: !this._expandedIndices[index]
+    };
+  }
+
+  /* Validation */
+
+  /**
+   * Helper to check if selectable cards has any selected values.
+   * @returns {boolean} True if at least one option is selected
+   */
+  _hasSelection() {
+    const val = this.elementValue;
+    if (!val) return false;
+    if (Array.isArray(val)) return val.length > 0;
+    if (typeof val === "string") return val.trim().length > 0;
+    return true;
+  }
+
+  /**
+   * Checks if the component is valid.
+   * Returns true during value updates to prevent blocking applyCallResp.
+   * @returns {boolean} True if valid or if applying value, false otherwise
+   */
+  @api checkValidity() {
+    // During value updates, always return true to allow the value to be applied
+    if (this._isApplyingValue) {
+      if (DEBUG)
+        console.log(
+          CLASS_NAME,
+          "checkValidity: returning true (applying value)"
+        );
+      return true;
+    }
+
+    const isRequired = this._propSetMap?.required === true;
+    const hasValue = this._hasSelection();
+    const valid = !isRequired || hasValue;
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "checkValidity called");
+      console.log(CLASS_NAME, "  isRequired:", isRequired);
+      console.log(CLASS_NAME, "  hasValue:", hasValue);
+      console.log(CLASS_NAME, "  valid:", valid);
+    }
+
+    // Set isValid to dispatch validation event to OmniScript
+    this.isValid = valid;
+
+    return valid;
+  }
+
+  /**
+   * Reports validity and updates the error state.
+   * Returns true during value updates to prevent blocking applyCallResp.
+   * @returns {boolean} True if valid or if applying value, false otherwise
+   */
+  @api reportValidity() {
+    // During value updates, always return true to allow the value to be applied
+    if (this._isApplyingValue) {
+      if (DEBUG)
+        console.log(
+          CLASS_NAME,
+          "reportValidity: returning true (applying value)"
+        );
+      return true;
+    }
+
+    const valid = this.checkValidity();
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "reportValidity called");
+      console.log(CLASS_NAME, "  valid:", valid);
+    }
+
+    // Update error display state - this is what sfGpsDsIsError uses
+    this.isError = !valid;
+    this._showValidation = !valid;
+
+    // Set error message when invalid
+    if (!valid) {
+      this.errorMessage =
+        this.mergedMessageWhenValueMissing ||
+        this._messageWhenValueMissing ||
+        "This field is required";
+    } else {
+      this.errorMessage = "";
+    }
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "  isError:", this.isError);
+      console.log(CLASS_NAME, "  errorMessage:", this.errorMessage);
+    }
+
+    return valid;
+  }
+
+  /* Lifecycle */
+
+  /**
+   * Initialize component variables.
+   * Sets the input selector for the parent validation framework.
+   */
+  initCompVariables() {
+    if (DEBUG) console.log(CLASS_NAME, "initCompVariables called");
+    super.initCompVariables();
+    // Set the selector so the parent class can find our validation input
+    this._inputSelector = "input[data-omni-input]";
+    if (DEBUG) {
+      console.log(CLASS_NAME, "  _inputSelector set to:", this._inputSelector);
+    }
+  }
+
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (DEBUG) console.log(CLASS_NAME, "connectedCallback called");
+    if (super.connectedCallback) super.connectedCallback();
+    this._readOnlyClass = "sfgpsdscaon-read-only";
+    this.classList.add("caon-scope");
+  }
+
+  _hasRendered = false;
+
+  renderedCallback() {
+    if (super.renderedCallback) super.renderedCallback();
+
+    // On first render, check validity to set initial validation state
+    // This ensures OmniScript knows if the field is initially invalid
+    if (!this._hasRendered) {
+      this._hasRendered = true;
+
+      // Defer to allow DOM to settle
+      // eslint-disable-next-line @lwc/lwc/no-async-operation
+      Promise.resolve().then(() => {
+        // Check validity without showing errors (user hasn't interacted yet)
+        // This dispatches the VALID/INVALID event to OmniScript
+        this.checkValidity();
+
+        if (DEBUG) {
+          console.log(CLASS_NAME, "renderedCallback: initial validity checked");
+          console.log(CLASS_NAME, "  isValid:", this.isValid);
+        }
+      });
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelectableCards/sfGpsDsCaOnFormSelectableCards.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSelectableCards/sfGpsDsCaOnFormSelectableCards.js-meta.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>true</isExposed>
+  <masterLabel>Ontario DS Form Selectable Cards</masterLabel>
+  <description
+  >Ontario DS Selectable Cards for OmniStudio. Cards with checkbox, title, description, expandable content. For service/activity selection.</description>
+  <targets>
+    <target>lightning__FlowScreen</target>
+    <target>lightningCommunity__Default</target>
+  </targets>
+  <targetConfigs>
+    <targetConfig targets="lightning__FlowScreen">
+      <property
+        name="configRequired"
+        type="Boolean"
+        label="Required"
+        description="Whether at least one selection is required"
+        default="false"
+      />
+      <property
+        name="configErrorMessage"
+        type="String"
+        label="Error Message"
+        description="Message shown when validation fails"
+      />
+      <property
+        name="configOptionsJson"
+        type="String"
+        label="Options JSON"
+        description="JSON array of options with value, label, description, badge, expandedContent"
+      />
+    </targetConfig>
+    <targetConfig targets="lightningCommunity__Default">
+      <property
+        name="configRequired"
+        type="Boolean"
+        label="Required"
+        description="Whether at least one selection is required"
+        default="false"
+      />
+      <property
+        name="configErrorMessage"
+        type="String"
+        label="Error Message"
+        description="Message shown when validation fails"
+      />
+      <property
+        name="configOptionsJson"
+        type="String"
+        label="Options JSON"
+        description="JSON array of options with value, label, description, badge, expandedContent"
+      />
+    </targetConfig>
+  </targetConfigs>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSiteSelectorTool/sfGpsDsCaOnFormSiteSelectorTool.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSiteSelectorTool/sfGpsDsCaOnFormSiteSelectorTool.css
@@ -1,0 +1,75 @@
+/**
+ * Ontario Design System - Form Site Selector Tool Styles
+ *
+ * OmniStudio wrapper for the Site Selector Tool.
+ */
+
+/* Container */
+.sfgpsdscaon-form-site-selector {
+  margin-bottom: 1.5rem;
+}
+
+/* Selected Address Display */
+.sfgpsdscaon-form-site-selector__selected {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  margin-top: 0.5rem;
+  background-color: #e8f4e8;
+  border: 1px solid #118847;
+  border-radius: 4px;
+}
+
+.sfgpsdscaon-form-site-selector__selected-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  flex: 1;
+}
+
+.sfgpsdscaon-form-site-selector__selected-icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+  fill: #118847;
+}
+
+.sfgpsdscaon-form-site-selector__selected-text {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+}
+
+.sfgpsdscaon-form-site-selector__clear-btn {
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: #0066cc;
+  font-size: 1rem;
+  text-decoration: underline;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.sfgpsdscaon-form-site-selector__clear-btn:hover {
+  color: #00478f;
+}
+
+.sfgpsdscaon-form-site-selector__clear-btn:focus {
+  box-shadow: 0 0 0 4px var(--ontario-colour-focus, #009adb);
+  outline: 4px solid transparent;
+}
+
+/* Error State */
+.sfgpsdscaon-form-site-selector--error
+  .sfgpsdscaon-form-site-selector__selected {
+  border-color: #cd0000;
+  background-color: #fce4e4;
+}
+
+.sfgpsdscaon-form-site-selector--error
+  .sfgpsdscaon-form-site-selector__selected-icon {
+  fill: #cd0000;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSiteSelectorTool/sfGpsDsCaOnFormSiteSelectorTool.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSiteSelectorTool/sfGpsDsCaOnFormSiteSelectorTool.html
@@ -1,0 +1,74 @@
+<template>
+  <div class={computedContainerClassName}>
+    <!-- Label -->
+    <label lwc:if={label} class={computedLabelClassName}>
+      {label}
+      <span lwc:if={isRequired} class="ontario-label__flag">(required)</span>
+    </label>
+
+    <!-- Help Text -->
+    <p lwc:if={helpText} class="ontario-hint" id="site-selector-hint">
+      {helpText}
+    </p>
+
+    <!-- Selected Address Display -->
+    <div
+      lwc:if={hasSelectedAddress}
+      class="sfgpsdscaon-form-site-selector__selected"
+    >
+      <div class="sfgpsdscaon-form-site-selector__selected-content">
+        <svg
+          class="sfgpsdscaon-form-site-selector__selected-icon"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
+            fill="currentColor"
+          />
+        </svg>
+        <span class="sfgpsdscaon-form-site-selector__selected-text">
+          {selectedAddressText}
+        </span>
+      </div>
+      <button
+        type="button"
+        class="sfgpsdscaon-form-site-selector__clear-btn"
+        onclick={handleClear}
+      >
+        Change
+      </button>
+    </div>
+
+    <!-- Site Selector Tool -->
+    <c-sf-gps-ds-ca-on-site-selector-tool
+      lwc:if={hasNoSelectedAddress}
+      button-label={buttonLabel}
+      modal-title={modalTitle}
+      vf-page-url={vfPageUrl}
+      default-latitude={defaultLatitude}
+      default-longitude={defaultLongitude}
+      onsave={handleSave}
+    ></c-sf-gps-ds-ca-on-site-selector-tool>
+
+    <!-- Validation Error Message -->
+    <div
+      lwc:if={showValidation}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <span class="ontario-error-messaging__icon">
+        <svg class="ontario-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+      <span class="ontario-error-messaging__content">
+        Please select an address to continue.
+      </span>
+    </div>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSiteSelectorTool/sfGpsDsCaOnFormSiteSelectorTool.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSiteSelectorTool/sfGpsDsCaOnFormSiteSelectorTool.js
@@ -1,0 +1,448 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { api, LightningElement, track } from "lwc";
+import { OmniscriptBaseMixin } from "omnistudio/omniscriptBaseMixin";
+import { computeClass } from "c/sfGpsDsHelpers";
+import fetchVFDomainURL from "@salesforce/apex/sfGpsDsCaOnSiteSelectorCtr.fetchVFDomainURL";
+
+/**
+ * @slot FormSiteSelectorTool
+ * @description OmniStudio Site Selector Tool with ESRI map integration.
+ * Provides address search and selection within OmniScript flows.
+ *
+ * ## LWR/LWS Compatibility
+ * - Uses OmniscriptBaseMixin for OmniScript integration
+ * - ESRI map in Visualforce iframe
+ * - postMessage for secure communication
+ *
+ * ## OmniScript Configuration
+ * - Type: Custom LWC
+ * - LWC Name: sfGpsDsCaOnFormSiteSelectorTool
+ *
+ * ## Custom Properties (set in OmniScript Designer)
+ * - label: Field label
+ * - helpText: Help text below label
+ * - buttonLabel: Label for trigger button
+ * - modalTitle: Title for modal header
+ * - defaultLatitude: Default map center latitude
+ * - defaultLongitude: Default map center longitude
+ * - required: Whether field is required
+ *
+ * ## Output Data Structure
+ * The component updates OmniScript JSON with flattened address fields:
+ * - streetAddress, city, province, postalCode, country, fullAddress
+ * - latitude, longitude
+ */
+export default class SfGpsDsCaOnFormSiteSelectorTool extends OmniscriptBaseMixin(
+  LightningElement
+) {
+  /* ========================================
+   * PUBLIC @api PROPERTIES
+   * For Custom LWC elements, OmniStudio passes config via @api properties
+   * ======================================== */
+
+  /** @type {string} Field label - passed from OmniScript */
+  @api configLabel;
+
+  /** @type {string} Help text - passed from OmniScript */
+  @api configHelpText;
+
+  /** @type {boolean} Whether field is required - passed from OmniScript */
+  @api configRequired;
+
+  /** @type {string} Button label - passed from OmniScript */
+  @api configButtonLabel;
+
+  /** @type {string} Modal title - passed from OmniScript */
+  @api configModalTitle;
+
+  /** @type {number} Default latitude - passed from OmniScript */
+  @api configDefaultLatitude;
+
+  /** @type {number} Default longitude - passed from OmniScript */
+  @api configDefaultLongitude;
+
+  /** @type {string} VF page URL path - passed from OmniScript */
+  @api configVfPageUrl;
+
+  /* ========================================
+   * PRIVATE PROPERTIES
+   * ======================================== */
+
+  /** @type {string} VF page URL */
+  @track _vfPageUrl = "";
+
+  /** @type {Object} Current address data */
+  @track _addressData = null;
+
+  /** @type {boolean} Whether to show validation error */
+  @track showValidation = false;
+
+  /* ========================================
+   * COMPUTED PROPERTIES - CONFIGURATION
+   * For Custom LWC elements, check @api props first, then jsonDef
+   * ======================================== */
+
+  /**
+   * Access standard OmniStudio properties from jsonDef.propSetMap
+   * @returns {Object}
+   */
+  get _propSetMap() {
+    return this.jsonDef?.propSetMap || {};
+  }
+
+  /**
+   * Access custom properties added via JSON Editor.
+   * OmniStudio nests custom propSetMap inside the standard propSetMap.
+   * Path: jsonDef.propSetMap.propSetMap.customProperty
+   * @returns {Object}
+   */
+  get _customPropSetMap() {
+    return this.jsonDef?.propSetMap?.propSetMap || {};
+  }
+
+  /**
+   * Get label - checks @api prop first, then jsonDef
+   * @returns {string}
+   */
+  get label() {
+    return this.configLabel || this._propSetMap?.label || "Site address";
+  }
+
+  /**
+   * Get help text - checks @api prop first, then jsonDef
+   * @returns {string}
+   */
+  get helpText() {
+    return this.configHelpText || this._propSetMap?.helpText || "";
+  }
+
+  /**
+   * Whether the field is required - checks @api prop first
+   * @returns {boolean}
+   */
+  get isRequired() {
+    if (this.configRequired !== undefined) {
+      return Boolean(this.configRequired);
+    }
+    return Boolean(this._propSetMap?.required);
+  }
+
+  /**
+   * Button label - checks @api prop first, then jsonDef
+   * @returns {string}
+   */
+  get buttonLabel() {
+    return (
+      this.configButtonLabel ||
+      this._customPropSetMap?.buttonLabel ||
+      this._propSetMap?.buttonLabel ||
+      "Site selector tool"
+    );
+  }
+
+  /**
+   * Modal title - checks @api prop first, then jsonDef
+   * @returns {string}
+   */
+  get modalTitle() {
+    return (
+      this.configModalTitle ||
+      this._customPropSetMap?.modalTitle ||
+      this._propSetMap?.modalTitle ||
+      "Site"
+    );
+  }
+
+  /**
+   * Default latitude - checks @api prop first, then jsonDef
+   * @returns {number}
+   */
+  get defaultLatitude() {
+    return (
+      this.configDefaultLatitude ||
+      this._customPropSetMap?.defaultLatitude ||
+      this._propSetMap?.defaultLatitude ||
+      43.6532
+    );
+  }
+
+  /**
+   * Default longitude - checks @api prop first, then jsonDef
+   * @returns {number}
+   */
+  get defaultLongitude() {
+    return (
+      this.configDefaultLongitude ||
+      this._customPropSetMap?.defaultLongitude ||
+      this._propSetMap?.defaultLongitude ||
+      -79.3832
+    );
+  }
+
+  /**
+   * VF Page URL with domain
+   * Checks @api configVfPageUrl first, then uses fetched URL
+   * @returns {string}
+   */
+  get vfPageUrl() {
+    // If full URL is provided via @api, use it directly
+    if (this.configVfPageUrl) {
+      return this.configVfPageUrl;
+    }
+    // Otherwise construct from fetched VF domain
+    if (this._vfPageUrl) {
+      return this._vfPageUrl + "/apex/sfGpsDsCaOnSiteSelectorPage";
+    }
+    return "";
+  }
+
+  /* ========================================
+   * COMPUTED PROPERTIES - DISPLAY
+   * ======================================== */
+
+  /**
+   * Whether address has been selected
+   * @returns {boolean}
+   */
+  get hasSelectedAddress() {
+    return this._addressData !== null;
+  }
+
+  /**
+   * Whether address has NOT been selected (for showing selector)
+   * @returns {boolean}
+   */
+  get hasNoSelectedAddress() {
+    return this._addressData === null;
+  }
+
+  /**
+   * Selected address display text
+   * @returns {string}
+   */
+  get selectedAddressText() {
+    if (!this._addressData?.address) return "";
+    return this._addressData.address.fullAddress || "";
+  }
+
+  /* ========================================
+   * COMPUTED PROPERTIES - CSS
+   * ======================================== */
+
+  /**
+   * Label CSS class
+   * @returns {string}
+   */
+  get computedLabelClassName() {
+    return computeClass({
+      "ontario-label": true,
+      "ontario-label--required": this.isRequired
+    });
+  }
+
+  /**
+   * Container CSS class
+   * @returns {string}
+   */
+  get computedContainerClassName() {
+    return "sfgpsdscaon-form-site-selector";
+  }
+
+  /* ========================================
+   * EVENT HANDLERS
+   * ======================================== */
+
+  /**
+   * Handles save event from site selector tool
+   * @param {CustomEvent} event
+   */
+  handleSave(event) {
+    const { address, coordinates } = event.detail;
+
+    // Store locally
+    this._addressData = { address, coordinates };
+
+    // Clear validation error when address is selected
+    this.showValidation = false;
+
+    // Set elementValue so OmniScript knows the field has a value
+    // OmniScript checks this property for required field validation
+    this.elementValue = address?.fullAddress;
+
+    // Update OmniScript data with flattened fields
+    this.omniUpdateDataJson({
+      streetAddress: address?.streetAddress,
+      city: address?.city,
+      province: address?.province,
+      postalCode: address?.postalCode,
+      country: address?.country,
+      fullAddress: address?.fullAddress,
+      latitude: coordinates?.latitude,
+      longitude: coordinates?.longitude
+    });
+
+    // Force OmniScript to re-validate and clear any cached validation state
+    // Use setTimeout to ensure this runs after the current event loop
+    // eslint-disable-next-line @lwc/lwc/no-async-operation
+    setTimeout(() => {
+      if (typeof this.omniValidate === "function") {
+        this.omniValidate(false); // false = don't show error messages
+      }
+    }, 0);
+  }
+
+  /**
+   * Handles clear button click
+   * @param {Event} event
+   */
+  handleClear(event) {
+    event.preventDefault();
+    this._addressData = null;
+
+    // Clear elementValue so OmniScript knows the field is empty
+    this.elementValue = null;
+
+    // Clear OmniScript data
+    this.omniUpdateDataJson({
+      streetAddress: null,
+      city: null,
+      province: null,
+      postalCode: null,
+      country: null,
+      fullAddress: null,
+      latitude: null,
+      longitude: null
+    });
+  }
+
+  /* ========================================
+   * LIFECYCLE METHODS
+   * ======================================== */
+
+  /**
+   * Component connected to DOM.
+   * Restores saved state from OmniScript JSON data.
+   */
+  connectedCallback() {
+    this.classList.add("caon-scope");
+    // Add data-omni-input to the HOST element so OmniScript can find and validate it
+    // This ensures OmniScript calls our @api checkValidity() directly
+    this.setAttribute("data-omni-input", "");
+    // Fetch VF domain URL (if not provided via @api)
+    if (!this.configVfPageUrl) {
+      this.loadVfDomainUrl();
+    }
+    // Restore saved state from OmniScript JSON
+    this.restoreSavedState();
+  }
+
+  /**
+   * Restores component state from OmniScript JSON data.
+   * Called on connectedCallback to handle "Previous" button navigation.
+   * @private
+   */
+  restoreSavedState() {
+    try {
+      // Get the saved data from OmniScript JSON using the element's path
+      const jsonPath = this.omniJsonDef?.JSONPath;
+      if (!jsonPath || !this.omniJsonData) return;
+
+      // Parse the JSON path to get the saved value
+      const pathParts = jsonPath.split(":");
+      let savedData = this.omniJsonData;
+
+      for (const part of pathParts) {
+        if (savedData && typeof savedData === "object") {
+          savedData = savedData[part];
+        } else {
+          savedData = null;
+          break;
+        }
+      }
+
+      // If we have saved data with address fields, restore the component state
+      if (savedData && (savedData.fullAddress || savedData.latitude)) {
+        this._addressData = {
+          address: {
+            streetAddress: savedData.streetAddress || "",
+            city: savedData.city || "",
+            province: savedData.province || "",
+            postalCode: savedData.postalCode || "",
+            country: savedData.country || "",
+            fullAddress: savedData.fullAddress || ""
+          },
+          coordinates: {
+            latitude: savedData.latitude,
+            longitude: savedData.longitude
+          }
+        };
+        // Restore elementValue so OmniScript knows the field has a value
+        this.elementValue = savedData.fullAddress || "";
+      }
+    } catch {
+      // Fail silently - state restoration is best-effort
+    }
+  }
+
+  /**
+   * Loads the Visualforce domain URL
+   * @private
+   */
+  async loadVfDomainUrl() {
+    try {
+      this._vfPageUrl = await fetchVFDomainURL();
+    } catch {
+      // VF domain URL fetch failed - component will show placeholder
+    }
+  }
+
+  /* ========================================
+   * VALIDATION METHODS - OmniScript Integration
+   * ======================================== */
+
+  /**
+   * Checks if the component is valid.
+   * Required for OmniScript "Next" button validation.
+   * @returns {boolean} True if valid (not required OR has value)
+   */
+  @api
+  checkValidity() {
+    // If not required, always valid
+    if (!this.isRequired) {
+      return true;
+    }
+    // If required, must have address data with a full address
+    return (
+      this._addressData !== null &&
+      Boolean(this._addressData?.address?.fullAddress)
+    );
+  }
+
+  /**
+   * Reports validity and shows validation messages.
+   * Required for OmniScript step validation.
+   * @returns {boolean} True if valid
+   */
+  @api
+  reportValidity() {
+    const isValid = this.checkValidity();
+    this.showValidation = !isValid;
+    return isValid;
+  }
+
+  /**
+   * Sets a custom validity message.
+   * @param {string} message - Custom error message
+   */
+  @api
+  setCustomValidity(message) {
+    this._customValidityMessage = message;
+    this.showValidation = Boolean(message);
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSiteSelectorTool/sfGpsDsCaOnFormSiteSelectorTool.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormSiteSelectorTool/sfGpsDsCaOnFormSiteSelectorTool.js-meta.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>true</isExposed>
+  <masterLabel>Ontario DS Form Site Selector Tool</masterLabel>
+  <description
+  >OmniStudio Site Selector with ESRI map integration. LWR/LWS compatible.</description>
+  <targets>
+    <target>lightning__FlowScreen</target>
+    <target>lightningCommunity__Default</target>
+  </targets>
+  <targetConfigs>
+    <targetConfig targets="lightning__FlowScreen">
+      <property
+        name="configLabel"
+        type="String"
+        label="Label"
+        description="Field label"
+      />
+      <property
+        name="configHelpText"
+        type="String"
+        label="Help Text"
+        description="Help text below label"
+      />
+      <property
+        name="configRequired"
+        type="Boolean"
+        label="Required"
+        description="Whether field is required"
+        default="false"
+      />
+      <property
+        name="configButtonLabel"
+        type="String"
+        label="Button Label"
+        description="Button label to open selector"
+        default="Site selector tool"
+      />
+      <property
+        name="configModalTitle"
+        type="String"
+        label="Modal Title"
+        description="Title for modal dialog"
+        default="Site"
+      />
+      <property
+        name="configDefaultLatitude"
+        type="String"
+        label="Default Latitude"
+        description="Default map center latitude"
+        default="43.6532"
+      />
+      <property
+        name="configDefaultLongitude"
+        type="String"
+        label="Default Longitude"
+        description="Default map center longitude"
+        default="-79.3832"
+      />
+      <property
+        name="configVfPageUrl"
+        type="String"
+        label="VF Page URL"
+        description="Full URL to Visualforce page (optional - auto-fetched if blank)"
+      />
+    </targetConfig>
+    <targetConfig targets="lightningCommunity__Default">
+      <property
+        name="configLabel"
+        type="String"
+        label="Label"
+        description="Field label"
+      />
+      <property
+        name="configHelpText"
+        type="String"
+        label="Help Text"
+        description="Help text below label"
+      />
+      <property
+        name="configRequired"
+        type="Boolean"
+        label="Required"
+        description="Whether field is required"
+        default="false"
+      />
+      <property
+        name="configButtonLabel"
+        type="String"
+        label="Button Label"
+        description="Button label to open selector"
+        default="Site selector tool"
+      />
+      <property
+        name="configModalTitle"
+        type="String"
+        label="Modal Title"
+        description="Title for modal dialog"
+        default="Site"
+      />
+      <property
+        name="configDefaultLatitude"
+        type="String"
+        label="Default Latitude"
+        description="Default map center latitude"
+        default="43.6532"
+      />
+      <property
+        name="configDefaultLongitude"
+        type="String"
+        label="Default Longitude"
+        description="Default map center longitude"
+        default="-79.3832"
+      />
+      <property
+        name="configVfPageUrl"
+        type="String"
+        label="VF Page URL"
+        description="Full URL to Visualforce page (optional - auto-fetched if blank)"
+      />
+    </targetConfig>
+  </targetConfigs>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStep/sfGpsDsCaOnFormStep.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStep/sfGpsDsCaOnFormStep.css
@@ -1,0 +1,143 @@
+/*
+ * Ontario Design System - Step Component Styles
+ * 
+ * AODA Accessibility Features:
+ * - Skip link visible on focus for keyboard users
+ * - Error summary with high contrast styling
+ * - Focus indicators meeting 3:1 contrast ratio
+ */
+
+.sfgpsdscaon-step {
+  padding: 0 1rem;
+  position: relative;
+}
+
+/* ========================================
+ * Skip Link - AODA Requirement
+ * Allows keyboard users to skip to navigation
+ * ======================================== */
+
+.sfgpsdscaon-step__skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--ontario-colour-primary, #1a5a96);
+  color: var(--ontario-colour-white, #ffffff);
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  font-weight: 600;
+  z-index: 100;
+  border-radius: 0 0 4px 4px;
+  transition: top 0.2s ease;
+}
+
+.sfgpsdscaon-step__skip-link:focus,
+.sfgpsdscaon-step__skip-link--visible {
+  top: 0;
+  outline: 3px solid var(--ontario-colour-warning, #ffcc00);
+  outline-offset: 2px;
+}
+
+.sfgpsdscaon-step__skip-link:hover {
+  background: var(--ontario-colour-primary-dark, #0d3d66);
+}
+
+/* ========================================
+ * Error Summary - AODA Requirement
+ * Provides grouped error feedback
+ * ======================================== */
+
+.sfgpsdscaon-step__error-summary {
+  background-color: var(--ontario-colour-error-light, #fef0f0);
+  border: 2px solid var(--ontario-colour-error, #cd0000);
+  border-left-width: 4px;
+  padding: 1rem 1.5rem;
+  margin-bottom: 1.5rem;
+  border-radius: 4px;
+}
+
+.sfgpsdscaon-step__error-summary:focus {
+  box-shadow: 0 0 0 4px var(--ontario-colour-focus, #009adb);
+  outline: 4px solid transparent;
+}
+
+.sfgpsdscaon-step__error-summary h3 {
+  color: var(--ontario-colour-error, #cd0000);
+  margin: 0 0 0.5rem 0;
+  font-size: 1.125rem;
+}
+
+.sfgpsdscaon-step__error-summary p {
+  margin: 0;
+  color: var(--ontario-colour-black, #1a1a1a);
+}
+
+.sfgpsdscaon-step__heading {
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.3;
+  margin: 1.5rem 0 1rem 0;
+  color: var(--ontario-colour-black, #1a1a1a);
+}
+
+.sfgpsdscaon-step__heading:focus {
+  box-shadow: 0 0 0 4px var(--ontario-colour-focus, #009adb);
+  outline: 4px solid transparent;
+}
+
+.sfgpsdscaon-step__separator {
+  border: none;
+  border-top: 1px solid var(--ontario-greyscale-20, #cccccc);
+  margin: 1rem 0 1.5rem 0;
+}
+
+/* Step content - slot element styling */
+.sfgpsdscaon-step__content,
+slot.sfgpsdscaon-step__content {
+  display: block;
+  margin-bottom: 2rem;
+}
+
+/* Style slotted children */
+::slotted(*) {
+  display: block;
+}
+
+.sfgpsdscaon-step__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--ontario-greyscale-20, #cccccc);
+}
+
+.sfgpsdscaon-step__back {
+  flex: 0 0 auto;
+}
+
+.sfgpsdscaon-step__primary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-left: auto;
+}
+
+/* Mobile responsive */
+@media (max-width: 640px) {
+  .sfgpsdscaon-step__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sfgpsdscaon-step__back {
+    order: 2;
+  }
+
+  .sfgpsdscaon-step__primary-actions {
+    order: 1;
+    flex-direction: column;
+    margin-left: 0;
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStep/sfGpsDsCaOnFormStep.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStep/sfGpsDsCaOnFormStep.html
@@ -1,0 +1,133 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System - Step Component for OmniStudio
+  
+  Provides step container with navigation buttons.
+  Uses Ontario DS button styling for consistent appearance.
+  
+  Compliance:
+  - LWR: Compatible (uses slot for content)
+  - LWS: Compatible (no restricted APIs)
+  - Ontario DS: Uses Ontario button classes
+  - WCAG 2.1 AA / AODA: 
+    - Skip link for keyboard users to bypass form content
+    - Step heading with aria-live for announcements
+    - Focus management on step change
+    - Keyboard accessible buttons
+    - Logical focus order
+    - Error summary region for validation feedback
+-->
+<template>
+  <template lwc:if={isStepActive}>
+    <div class="sfgpsdscaon-step" role="region" aria-label={stepAriaLabel}>
+      <!-- Skip link for keyboard users - AODA requirement -->
+      <a
+        href="#step-navigation"
+        class="sfgpsdscaon-step__skip-link ontario-show-for-sr"
+        onfocus={handleSkipLinkFocus}
+        onblur={handleSkipLinkBlur}
+        onclick={handleSkipLinkClick}
+      >
+        Skip to navigation buttons
+      </a>
+
+      <!-- Step heading -->
+      <h2
+        lwc:if={mergedLabel}
+        id="step-heading"
+        class="sfgpsdscaon-step__heading"
+        tabindex="-1"
+      >
+        {mergedLabel}
+      </h2>
+
+      <!-- Screen reader announcement for step change -->
+      <div
+        class="ontario-show-for-sr"
+        aria-live="polite"
+        aria-atomic="true"
+        role="status"
+      >
+        <span lwc:if={stepAnnouncement}>{stepAnnouncement}</span>
+      </div>
+
+      <hr class="sfgpsdscaon-step__separator" aria-hidden="true" />
+
+      <!-- Error summary region - appears when validation errors exist -->
+      <div
+        lwc:if={hasValidationErrors}
+        class="sfgpsdscaon-step__error-summary ontario-callout ontario-callout--error"
+        role="alert"
+        aria-live="assertive"
+        tabindex="-1"
+      >
+        <h3 class="ontario-callout__title ontario-h5">
+          There are errors on this page
+        </h3>
+        <p>
+          Please review and correct the highlighted fields before continuing.
+        </p>
+      </div>
+
+      <!-- Step content (slot for child elements) -->
+      <!-- Note: slot must not be wrapped for OmniStudio Custom LWC compatibility -->
+      <slot class="sfgpsdscaon-step__content" id="step-content"></slot>
+
+      <!-- Navigation buttons - skip link target -->
+      <nav
+        lwc:if={computedShowSep}
+        id="step-navigation"
+        class="sfgpsdscaon-step__actions"
+        aria-label="Step navigation"
+      >
+        <!-- Back button -->
+        <div lwc:if={showPrev} class="sfgpsdscaon-step__back">
+          <button
+            type="button"
+            class="ontario-button ontario-button--tertiary"
+            disabled={disabledButtons}
+            onclick={handleBack}
+            aria-describedby="step-heading"
+          >
+            <svg
+              class="ontario-icon"
+              aria-hidden="true"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+              />
+            </svg>
+            {mergedPreviousLabel}
+          </button>
+        </div>
+
+        <!-- Primary actions -->
+        <div class="sfgpsdscaon-step__primary-actions">
+          <!-- Save for later button -->
+          <button
+            lwc:if={showSave}
+            type="button"
+            class="ontario-button ontario-button--secondary"
+            disabled={disabledButtons}
+            onclick={handleSave}
+          >
+            {mergedSaveLabel}
+          </button>
+
+          <!-- Next/Continue button -->
+          <button
+            lwc:if={showNext}
+            type="button"
+            class="ontario-button ontario-button--primary"
+            disabled={disabledButtons}
+            onclick={handleNext}
+          >
+            {mergedNextLabel}
+          </button>
+        </div>
+      </nav>
+    </div>
+  </template>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStep/sfGpsDsCaOnFormStep.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStep/sfGpsDsCaOnFormStep.js
@@ -1,0 +1,363 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { track } from "lwc";
+import SfGpsDsFormStep from "c/sfGpsDsFormStep";
+import tmpl from "./sfGpsDsCaOnFormStep.html";
+
+const DEBUG = false;
+const CLASS_NAME = "SfGpsDsCaOnFormStep";
+
+/**
+ * @slot Step
+ * @description Ontario Design System Step component for OmniStudio forms.
+ * Provides step container with navigation buttons (Previous, Next, Save).
+ * Uses Ontario DS button styling.
+ *
+ * Compliance:
+ * - LWR: Uses slot for step content
+ * - LWS: No eval(), proper namespace imports
+ * - Ontario DS: Uses Ontario button styling
+ * - WCAG 2.1 AA / AODA:
+ *   - Skip link for keyboard users to bypass form content
+ *   - Step heading with focus management on step change
+ *   - Screen reader announcement for step changes
+ *   - Error summary for validation failures
+ *   - Keyboard accessible navigation
+ */
+export default class SfGpsDsCaOnFormStep extends SfGpsDsFormStep {
+  /* ========================================
+   * PRIVATE PROPERTIES
+   * ======================================== */
+
+  /** @type {boolean} Tracked property to force re-render when active state changes */
+  @track _isActive = false;
+
+  /** @type {boolean} Tracks if heading has been focused for this step */
+  _headingFocused = false;
+
+  /** @type {boolean} Tracks if skip link is visible */
+  _skipLinkVisible = false;
+
+  /** @type {string} Current step announcement for screen readers */
+  _stepAnnouncement = "";
+
+  /* ========================================
+   * COMPUTED PROPERTIES
+   * ======================================== */
+
+  /**
+   * Safely checks if the step is active.
+   * Handles cases where jsonDef might not be set yet.
+   * @returns {boolean} True if step is active
+   */
+  get isStepActive() {
+    // Return the tracked property for proper reactivity
+    return this._isActive;
+  }
+
+  /**
+   * Updates the tracked _isActive property based on jsonDef.bAccordionActive.
+   * Called from renderedCallback to ensure reactivity.
+   */
+  _updateActiveState() {
+    const isActive = Boolean(this.jsonDef?.bAccordionActive);
+
+    if (this._isActive !== isActive) {
+      if (DEBUG) {
+        console.log(
+          CLASS_NAME,
+          "_updateActiveState CHANGE",
+          "from=" + this._isActive,
+          "to=" + isActive,
+          "jsonDef.name=" + this.jsonDef?.name
+        );
+      }
+      this._isActive = isActive;
+    }
+  }
+
+  /**
+   * Determines if navigation section should be shown.
+   * @returns {boolean} True if any navigation button is visible
+   */
+  get computedShowSep() {
+    return this.showNext || this.showPrev || this.showSave;
+  }
+
+  /**
+   * Generates accessible label for the step region.
+   * @returns {string} Accessible label combining step number and title
+   */
+  get stepAriaLabel() {
+    const label = this.mergedLabel || "Step";
+    return `${label} - Form section`;
+  }
+
+  /**
+   * Generates announcement text for screen readers when step changes.
+   * @returns {string} Announcement text
+   */
+  get stepAnnouncement() {
+    return this._stepAnnouncement;
+  }
+
+  /**
+   * Checks if there are validation errors in the current step.
+   * Looks for OmniScript validation state.
+   * @returns {boolean} True if validation errors exist
+   */
+  get hasValidationErrors() {
+    // Check if OmniScript has reported validation errors for this step
+    // This integrates with OmniScript's validation framework
+    try {
+      const childElements = this.querySelectorAll("[data-omni-input]");
+      for (const el of childElements) {
+        if (
+          el.classList?.contains("slds-has-error") ||
+          el.classList?.contains("nds-has-error") ||
+          el.getAttribute("aria-invalid") === "true"
+        ) {
+          return true;
+        }
+      }
+    } catch {
+      // Fail silently - validation check is a progressive enhancement
+    }
+    return false;
+  }
+
+  /* ========================================
+   * EVENT HANDLERS
+   * ======================================== */
+
+  /**
+   * Handles Next button click.
+   * Uses dispatchOmniEventUtil for proper OmniScript event handling in LWR.
+   * @param {Event} e - Click event
+   */
+  handleNext(e) {
+    e.stopPropagation();
+
+    this.disabledButtons = true;
+    // eslint-disable-next-line @lwc/lwc/no-async-operation
+    setTimeout(() => {
+      this.disabledButtons = false;
+    }, 1000);
+
+    // Use dispatchOmniEventUtil for proper OmniScript integration
+    if (typeof this.dispatchOmniEventUtil === "function") {
+      this.dispatchOmniEventUtil(
+        this,
+        { moveToStep: "next" },
+        "omniautoadvance"
+      );
+    } else {
+      // Fallback for non-OmniScript contexts
+      this.dispatchEvent(
+        new CustomEvent("omniautoadvance", {
+          bubbles: true,
+          composed: true,
+          cancelable: true,
+          detail: { moveToStep: "next" }
+        })
+      );
+    }
+  }
+
+  /**
+   * Handles Back button click.
+   * Uses dispatchOmniEventUtil for proper OmniScript event handling in LWR.
+   * @param {Event} e - Click event
+   */
+  handleBack(e) {
+    e.stopPropagation();
+
+    this.disabledButtons = true;
+    // eslint-disable-next-line @lwc/lwc/no-async-operation
+    setTimeout(() => {
+      this.disabledButtons = false;
+    }, 1000);
+
+    // Use dispatchOmniEventUtil for proper OmniScript integration
+    if (typeof this.dispatchOmniEventUtil === "function") {
+      this.dispatchOmniEventUtil(
+        this,
+        { moveToStep: "previous" },
+        "omniautoadvance"
+      );
+    } else {
+      // Fallback for non-OmniScript contexts
+      this.dispatchEvent(
+        new CustomEvent("omniautoadvance", {
+          bubbles: true,
+          composed: true,
+          cancelable: true,
+          detail: { moveToStep: "previous" }
+        })
+      );
+    }
+  }
+
+  /**
+   * Handles skip link focus - makes it visible.
+   * AODA: Skip links should be visible when focused.
+   */
+  handleSkipLinkFocus() {
+    this._skipLinkVisible = true;
+    const skipLink = this.querySelector(".sfgpsdscaon-step__skip-link");
+    if (skipLink) {
+      skipLink.classList.add("sfgpsdscaon-step__skip-link--visible");
+    }
+  }
+
+  /**
+   * Handles skip link blur - hides it again.
+   */
+  handleSkipLinkBlur() {
+    this._skipLinkVisible = false;
+    const skipLink = this.querySelector(".sfgpsdscaon-step__skip-link");
+    if (skipLink) {
+      skipLink.classList.remove("sfgpsdscaon-step__skip-link--visible");
+    }
+  }
+
+  /**
+   * Handles skip link click - moves focus to navigation.
+   * Shadow DOM doesn't support anchor navigation, so we handle it in JS.
+   * @param {Event} event - Click event
+   */
+  handleSkipLinkClick(event) {
+    event.preventDefault();
+    const nav = this.template.querySelector("#step-navigation");
+    if (nav) {
+      // Make the nav focusable temporarily and focus it
+      nav.setAttribute("tabindex", "-1");
+      nav.focus();
+      // Find the first focusable button and focus it
+      const firstButton = nav.querySelector("button:not([disabled])");
+      if (firstButton) {
+        firstButton.focus();
+      }
+    }
+  }
+
+  /* ========================================
+   * PUBLIC METHODS
+   * ======================================== */
+
+  /**
+   * Moves focus to the error summary region.
+   * Called after validation fails to help screen reader users.
+   * AODA: Focus should move to error summary on validation failure.
+   */
+  focusErrorSummary() {
+    const errorSummary = this.querySelector(".sfgpsdscaon-step__error-summary");
+    if (errorSummary) {
+      errorSummary.focus();
+    }
+  }
+
+  /**
+   * Announces step change to screen readers.
+   * @param {string} message - Message to announce
+   */
+  announceStepChange(message) {
+    this._stepAnnouncement = message;
+    // Clear announcement after a delay to allow re-announcement
+    // eslint-disable-next-line @lwc/lwc/no-async-operation
+    setTimeout(() => {
+      this._stepAnnouncement = "";
+    }, 1000);
+  }
+
+  /* ========================================
+   * LIFECYCLE HOOKS
+   * ======================================== */
+
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (DEBUG) {
+      console.log(
+        CLASS_NAME,
+        "connectedCallback START",
+        "hasJsonDef=" + Boolean(this.jsonDef),
+        "type=" + this.jsonDef?.type,
+        "name=" + this.jsonDef?.name,
+        "bAccordionActive=" + this.jsonDef?.bAccordionActive,
+        "label=" + this.jsonDef?.propSetMap?.label
+      );
+    }
+
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    this.classList.add("caon-scope");
+
+    // Initialize active state
+    this._updateActiveState();
+
+    // Announce step change for screen readers
+    if (this.mergedLabel && this._isActive) {
+      this.announceStepChange(`Now on step: ${this.mergedLabel}`);
+    }
+
+    if (DEBUG) {
+      console.log(
+        CLASS_NAME,
+        "connectedCallback END",
+        "_isActive=" + this._isActive
+      );
+    }
+  }
+
+  /**
+   * Focus the step heading when rendered for accessibility.
+   * AODA: Focus should move to new content when page/section changes.
+   */
+  renderedCallback() {
+    if (DEBUG) {
+      console.log(
+        CLASS_NAME,
+        "renderedCallback",
+        "name=" + this.jsonDef?.name,
+        "_isActive=" + this._isActive,
+        "bAccordionActive=" + this.jsonDef?.bAccordionActive
+      );
+    }
+
+    // Update active state first - this triggers reactivity
+    this._updateActiveState();
+
+    if (super.renderedCallback) {
+      super.renderedCallback();
+    }
+
+    // Focus step heading for screen reader announcement
+    const heading = this.querySelector(".sfgpsdscaon-step__heading");
+    if (heading && !this._headingFocused && this._isActive) {
+      // Use setTimeout to ensure DOM is ready
+      // eslint-disable-next-line @lwc/lwc/no-async-operation
+      setTimeout(() => {
+        heading.focus();
+      }, 100);
+      this._headingFocused = true;
+    }
+
+    // Check for validation errors and focus error summary if present
+    if (this.hasValidationErrors && !this._errorFocused) {
+      this.focusErrorSummary();
+      this._errorFocused = true;
+    } else if (!this.hasValidationErrors) {
+      this._errorFocused = false;
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStep/sfGpsDsCaOnFormStep.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStep/sfGpsDsCaOnFormStep.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Step component for OmniStudio standard runtime forms. Provides step container with navigation. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStepChart/sfGpsDsCaOnFormStepChart.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStepChart/sfGpsDsCaOnFormStepChart.css
@@ -1,0 +1,7 @@
+/*
+ * Ontario Design System - Step Chart Component Styles
+ */
+
+.sfgpsdscaon-step-chart {
+  margin: 1.5rem 0;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStepChart/sfGpsDsCaOnFormStepChart.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStepChart/sfGpsDsCaOnFormStepChart.html
@@ -1,0 +1,46 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System - Step Chart Component for OmniStudio
+  
+  Displays visual progress indicator for multi-step forms.
+  Uses Ontario DS step indicator web component.
+  
+  Compliance:
+  - LWR: Compatible (uses Ontario DS web component with lwc:external)
+  - LWS: Compatible (no restricted APIs)
+  - Ontario DS: Uses ontario-step-indicator component
+  - WCAG 2.1 AA / AODA: 
+    - Progress accessible to screen readers via aria-label and live region
+    - Current step clearly indicated visually and programmatically
+    - Progress percentage announced on step change
+-->
+<template>
+  <div
+    class="sfgpsdscaon-step-chart"
+    role="region"
+    aria-label="Form progress indicator"
+  >
+    <!-- Screen reader announcement for step progress - AODA -->
+    <div
+      class="ontario-show-for-sr"
+      aria-live="polite"
+      aria-atomic="true"
+      role="status"
+    >
+      <span lwc:if={progressAnnouncement}>{progressAnnouncement}</span>
+    </div>
+
+    <!-- Visual progress indicator -->
+    <ontario-step-indicator
+      lwc:external
+      current-step={sfGpsDsStepNumber}
+      number-of-steps={sfGpsDsStepCount}
+      percentage-complete={computedPercentage}
+      show-back-button="false"
+      aria-hidden="true"
+    ></ontario-step-indicator>
+
+    <!-- Accessible progress description -->
+    <p class="ontario-show-for-sr">{accessibleProgressDescription}</p>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStepChart/sfGpsDsCaOnFormStepChart.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStepChart/sfGpsDsCaOnFormStepChart.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import SfGpsDsFormStepChart from "c/sfGpsDsFormStepChart";
+import tmpl from "./sfGpsDsCaOnFormStepChart.html";
+
+/**
+ * @slot StepChart
+ * @description Ontario Design System Step Chart component for OmniStudio forms.
+ * Displays visual progress indicator for multi-step forms.
+ * Uses Ontario DS step indicator web component.
+ *
+ * Compliance:
+ * - LWR: Uses Ontario DS web component with lwc:external
+ * - LWS: No eval(), proper namespace imports
+ * - Ontario DS: Uses ontario-step-indicator web component
+ * - WCAG 2.1 AA / AODA:
+ *   - Progress information accessible to screen readers via live region
+ *   - Current step clearly indicated visually and programmatically
+ *   - Progress percentage announced on step change
+ */
+export default class SfGpsDsCaOnFormStepChart extends SfGpsDsFormStepChart {
+  /* ========================================
+   * PRIVATE PROPERTIES
+   * ======================================== */
+
+  /** @type {number} Previous step number for change detection */
+  _previousStep = 0;
+
+  /** @type {string} Current progress announcement */
+  _progressAnnouncement = "";
+
+  /* ========================================
+   * COMPUTED PROPERTIES
+   * ======================================== */
+
+  /**
+   * Calculates the progress percentage for the step indicator.
+   * @returns {number} Progress percentage (0-100)
+   */
+  get computedPercentage() {
+    const data = this.calculateStepData(this.jsonDef?.asIndex);
+    return data.value;
+  }
+
+  /**
+   * Determines if back button should be shown.
+   * @returns {boolean} True if not on first step
+   */
+  get computedShowBackButton() {
+    return this.sfGpsDsStepIndex > 0;
+  }
+
+  /**
+   * Generates screen reader announcement for progress changes.
+   * AODA: Screen readers should announce progress updates.
+   * @returns {string} Progress announcement text
+   */
+  get progressAnnouncement() {
+    return this._progressAnnouncement;
+  }
+
+  /**
+   * Generates accessible description of progress for screen readers.
+   * AODA: Provide text alternative for visual progress indicator.
+   * @returns {string} Human-readable progress description
+   */
+  get accessibleProgressDescription() {
+    const currentStep = this.sfGpsDsStepNumber || 1;
+    const totalSteps = this.sfGpsDsStepCount || 1;
+    const percentage = Math.round(this.computedPercentage);
+
+    return `Step ${currentStep} of ${totalSteps}. ${percentage}% complete.`;
+  }
+
+  /* ========================================
+   * PRIVATE METHODS
+   * ======================================== */
+
+  /**
+   * Announces step progress change to screen readers.
+   * @private
+   */
+  _announceProgress() {
+    const currentStep = this.sfGpsDsStepNumber || 1;
+    const totalSteps = this.sfGpsDsStepCount || 1;
+    const percentage = Math.round(this.computedPercentage);
+
+    this._progressAnnouncement = `Progress: Step ${currentStep} of ${totalSteps}, ${percentage}% complete`;
+
+    // Clear announcement after delay to allow re-announcement on next change
+    // eslint-disable-next-line @lwc/lwc/no-async-operation
+    setTimeout(() => {
+      this._progressAnnouncement = "";
+    }, 1000);
+  }
+
+  /* ========================================
+   * LIFECYCLE HOOKS
+   * ======================================== */
+
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    this.classList.add("caon-scope");
+    this._previousStep = this.sfGpsDsStepNumber || 0;
+  }
+
+  /**
+   * Announces progress when step changes.
+   * AODA: Progress updates should be announced to screen readers.
+   */
+  renderedCallback() {
+    if (super.renderedCallback) {
+      super.renderedCallback();
+    }
+
+    // Detect step change and announce
+    const currentStep = this.sfGpsDsStepNumber || 0;
+    if (currentStep !== this._previousStep) {
+      this._announceProgress();
+      this._previousStep = currentStep;
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStepChart/sfGpsDsCaOnFormStepChart.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormStepChart/sfGpsDsCaOnFormStepChart.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Step Chart component for OmniStudio standard runtime forms. Displays progress indicator. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTelephone/sfGpsDsCaOnFormTelephone.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTelephone/sfGpsDsCaOnFormTelephone.css
@@ -1,0 +1,64 @@
+.ontario-form-group {
+  margin-bottom: 1.5rem;
+}
+.ontario-label {
+  display: block;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+}
+.ontario-label__flag {
+  font-weight: 400;
+}
+.ontario-hint {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+.ontario-input {
+  display: block;
+  width: 100%;
+  max-width: 48rem;
+  padding: 0.625rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background-color: #fff;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+}
+.ontario-input:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 0;
+  box-shadow: 0 0 0 4px #009ade;
+}
+.ontario-input:disabled {
+  background-color: #e6e6e6;
+  border-color: #666;
+  color: #666;
+  cursor: not-allowed;
+}
+.ontario-input__error {
+  border-color: #cd0000;
+}
+.ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #cd0000;
+  margin-bottom: 0.5rem;
+}
+.ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  fill: #cd0000;
+}
+.ontario-error-messaging__content {
+  font-size: 1rem;
+  line-height: 1.5;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTelephone/sfGpsDsCaOnFormTelephone.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTelephone/sfGpsDsCaOnFormTelephone.html
@@ -1,0 +1,61 @@
+<!-- sldsValidatorIgnore -->
+<template>
+  <div class="ontario-form-group">
+    <label class="ontario-label" for={inputId}>
+      {mergedLabel}
+      <span lwc:if={showRequiredFlag} class="ontario-label__flag"
+        >(required)</span
+      >
+      <span lwc:if={showOptionalFlag} class="ontario-label__flag"
+        >(optional)</span
+      >
+    </label>
+
+    <p lwc:if={mergedHelpText} id={hintId} class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <div
+      lwc:if={sfGpsDsIsError}
+      id={errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <input
+      type="tel"
+      id={inputId}
+      name={_name}
+      class={computedInputClassName}
+      value={elementValue}
+      placeholder={mergedPlaceholder}
+      disabled={_propSetMap.disabled}
+      readonly={_propSetMap.readOnly}
+      required={_propSetMap.required}
+      aria-required={computedAriaRequired}
+      autocomplete="tel"
+      pattern={_patternVal}
+      aria-describedby={computedAriaDescribedBy}
+      aria-invalid={computedAriaInvalid}
+      data-omni-input
+      oninput={handleInput}
+      onchange={handleChange}
+      onblur={handleBlur}
+    />
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTelephone/sfGpsDsCaOnFormTelephone.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTelephone/sfGpsDsCaOnFormTelephone.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import SfGpsDsFormText from "c/sfGpsDsFormText";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormTelephone.html";
+
+export default class SfGpsDsCaOnFormTelephone extends SfGpsDsFormText {
+  _uniqueId = `tel-${Math.random().toString(36).substring(2, 11)}`;
+
+  get inputId() {
+    return `${this._uniqueId}-input`;
+  }
+  get hintId() {
+    return `${this._uniqueId}-hint`;
+  }
+  get errorId() {
+    return `${this._uniqueId}-error`;
+  }
+  get showRequiredFlag() {
+    return this._propSetMap?.required === true;
+  }
+  get showOptionalFlag() {
+    return this._propSetMap?.optional === true && !this._propSetMap?.required;
+  }
+  get computedInputClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "ontario-input__error": this.sfGpsDsIsError
+    });
+  }
+  get computedAriaDescribedBy() {
+    return computeClass({
+      [this.hintId]: this.mergedHelpText,
+      [this.errorId]: this.sfGpsDsIsError
+    });
+  }
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+  get computedAriaRequired() {
+    return this._propSetMap?.required ? "true" : "false";
+  }
+
+  render() {
+    return tmpl;
+  }
+  connectedCallback() {
+    if (super.connectedCallback) super.connectedCallback();
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTelephone/sfGpsDsCaOnFormTelephone.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTelephone/sfGpsDsCaOnFormTelephone.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Telephone input for OmniStudio standard runtime forms. LWR and LWS compatible. WCAG 2.1 AA compliant. Provides tel input type for mobile keyboard optimization.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormText/sfGpsDsCaOnFormText.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormText/sfGpsDsCaOnFormText.css
@@ -1,0 +1,85 @@
+/*
+ * Ontario Design System Text Input styles for OmniStudio forms.
+ * Shadow DOM scoped styles.
+ */
+
+.ontario-form-group {
+  margin-bottom: 1.5rem;
+}
+
+.ontario-label {
+  display: block;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+}
+
+.ontario-label__flag {
+  font-weight: 400;
+  font-style: normal;
+}
+
+.ontario-hint {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+
+.ontario-input {
+  display: block;
+  width: 100%;
+  max-width: 48rem;
+  padding: 0.625rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background-color: #ffffff;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+}
+
+.ontario-input:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 0;
+  box-shadow: 0 0 0 4px #009ade;
+}
+
+.ontario-input:disabled {
+  background-color: #e6e6e6;
+  border-color: #666666;
+  color: #666666;
+  cursor: not-allowed;
+}
+
+.ontario-input[readonly] {
+  background-color: #f5f5f5;
+  border-color: #666666;
+}
+
+.ontario-input__error {
+  border-color: #cd0000;
+}
+
+.ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #cd0000;
+  margin-bottom: 0.5rem;
+}
+
+.ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  fill: #cd0000;
+}
+
+.ontario-error-messaging__content {
+  font-size: 1rem;
+  line-height: 1.5;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormText/sfGpsDsCaOnFormText.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormText/sfGpsDsCaOnFormText.html
@@ -1,0 +1,71 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System Text Input for OmniStudio forms.
+  Renders inline (Shadow DOM) without Light DOM child components.
+-->
+<template>
+  <div class="ontario-form-group">
+    <!-- Label -->
+    <label class="ontario-label" for={inputId}>
+      {mergedLabel}
+      <span lwc:if={showRequiredFlag} class="ontario-label__flag"
+        >(required)</span
+      >
+      <span lwc:if={showOptionalFlag} class="ontario-label__flag"
+        >(optional)</span
+      >
+    </label>
+
+    <!-- Hint text -->
+    <p lwc:if={mergedHelpText} id={hintId} class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <!-- Error message -->
+    <div
+      lwc:if={sfGpsDsIsError}
+      id={errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <!-- Input field -->
+    <input
+      type={_inputType}
+      id={inputId}
+      name={_name}
+      class={computedInputClassName}
+      value={elementValue}
+      placeholder={mergedPlaceholder}
+      disabled={_propSetMap.disabled}
+      readonly={_propSetMap.readOnly}
+      required={_propSetMap.required}
+      aria-required={computedAriaRequired}
+      minlength={_minLength}
+      maxlength={_maxLength}
+      pattern={_patternVal}
+      autocomplete={_autocomplete}
+      aria-describedby={computedAriaDescribedBy}
+      aria-invalid={computedAriaInvalid}
+      data-omni-input
+      oninput={handleInput}
+      onchange={handleChange}
+      onblur={handleBlur}
+    />
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormText/sfGpsDsCaOnFormText.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormText/sfGpsDsCaOnFormText.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import SfGpsDsFormText from "c/sfGpsDsFormText";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormText.html";
+
+/**
+ * @slot Text
+ * @description Ontario Design System Text Input component for OmniStudio forms.
+ * Renders inline (Shadow DOM) - does not use Light DOM child components.
+ *
+ * Compliance:
+ * - LWR: Compatible (Shadow DOM)
+ * - LWS: Compatible
+ * - Ontario DS: Uses Ontario form styling
+ * - WCAG 2.1 AA / AODA: Focus management, aria attributes
+ */
+export default class SfGpsDsCaOnFormText extends SfGpsDsFormText {
+  _uniqueId = `text-${Math.random().toString(36).substring(2, 11)}`;
+  _previousErrorState = null;
+
+  /* ========================================
+   * COMPUTED PROPERTIES
+   * ======================================== */
+
+  get inputId() {
+    return `${this._uniqueId}-input`;
+  }
+
+  get hintId() {
+    return `${this._uniqueId}-hint`;
+  }
+
+  get errorId() {
+    return `${this._uniqueId}-error`;
+  }
+
+  get showRequiredFlag() {
+    return this._propSetMap?.required === true;
+  }
+
+  get showOptionalFlag() {
+    return this._propSetMap?.optional === true && !this._propSetMap?.required;
+  }
+
+  get computedInputClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "ontario-input__error": this.sfGpsDsIsError
+    });
+  }
+
+  get computedAriaDescribedBy() {
+    return computeClass({
+      [this.hintId]: this.mergedHelpText,
+      [this.errorId]: this.sfGpsDsIsError
+    });
+  }
+
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+
+  get computedAriaRequired() {
+    return this._propSetMap?.required ? "true" : "false";
+  }
+
+  /* ========================================
+   * PUBLIC METHODS - AODA Accessibility
+   * ======================================== */
+
+  focusInput() {
+    try {
+      const input = this.template.querySelector("input");
+      if (input) {
+        input.focus();
+      }
+    } catch {
+      // Fail silently
+    }
+  }
+
+  hasValidationError() {
+    return this.sfGpsDsIsError || false;
+  }
+
+  /* ========================================
+   * LIFECYCLE HOOKS
+   * ======================================== */
+
+  render() {
+    return tmpl;
+  }
+
+  connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+    this._readOnlyClass = "sfgpsdscaon-read-only";
+    this.classList.add("caon-scope");
+  }
+
+  renderedCallback() {
+    if (super.renderedCallback) {
+      super.renderedCallback();
+    }
+
+    const currentErrorState = Boolean(this.sfGpsDsIsError);
+    if (currentErrorState !== this._previousErrorState) {
+      this._previousErrorState = currentErrorState;
+      if (currentErrorState) {
+        this.setAttribute("data-has-error", "true");
+      } else {
+        this.removeAttribute("data-has-error");
+      }
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormText/sfGpsDsCaOnFormText.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormText/sfGpsDsCaOnFormText.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextBlock/sfGpsDsCaOnFormTextBlock.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextBlock/sfGpsDsCaOnFormTextBlock.css
@@ -1,0 +1,107 @@
+/* Ontario Design System - Text Block Styles */
+
+/* Apply Ontario DS typography to text block content */
+.ontario-text-block {
+  font-family: var(--ontario-font-family, "Open Sans", sans-serif);
+  font-size: var(--ontario-font-size-body, 1rem);
+  line-height: var(--ontario-line-height-body, 1.6);
+  color: var(--ontario-colour-black, #1a1a1a);
+}
+
+/* Headings within text blocks */
+.ontario-text-block h1,
+.ontario-text-block h2,
+.ontario-text-block h3,
+.ontario-text-block h4,
+.ontario-text-block h5,
+.ontario-text-block h6 {
+  font-family: var(--ontario-font-family-heading, "Raleway", sans-serif);
+  font-weight: 700;
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.ontario-text-block h1 {
+  font-size: 2rem;
+}
+
+.ontario-text-block h2 {
+  font-size: 1.75rem;
+}
+
+.ontario-text-block h3 {
+  font-size: 1.5rem;
+}
+
+.ontario-text-block h4 {
+  font-size: 1.25rem;
+}
+
+/* Paragraphs */
+.ontario-text-block p {
+  margin-bottom: 1rem;
+}
+
+/* Links */
+.ontario-text-block a {
+  color: var(--ontario-colour-link, #0066cc);
+  text-decoration: underline;
+}
+
+.ontario-text-block a:hover {
+  color: var(--ontario-colour-link-hover, #00478f);
+}
+
+.ontario-text-block a:focus {
+  outline: 4px solid var(--ontario-colour-focus, #009acd);
+  outline-offset: 2px;
+}
+
+/* Lists */
+.ontario-text-block ul,
+.ontario-text-block ol {
+  margin-bottom: 1rem;
+  padding-left: 2rem;
+}
+
+.ontario-text-block li {
+  margin-bottom: 0.5rem;
+}
+
+/* Strong and emphasis */
+.ontario-text-block strong,
+.ontario-text-block b {
+  font-weight: 700;
+}
+
+.ontario-text-block em,
+.ontario-text-block i {
+  font-style: italic;
+}
+
+/* Blockquotes within text blocks */
+.ontario-text-block blockquote {
+  border-left: 4px solid var(--ontario-colour-black, #1a1a1a);
+  padding-left: 1rem;
+  margin: 1rem 0;
+  font-style: italic;
+}
+
+/* Tables within text blocks */
+.ontario-text-block table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+.ontario-text-block th,
+.ontario-text-block td {
+  border: 1px solid var(--ontario-colour-grey-light, #ccc);
+  padding: 0.75rem;
+  text-align: left;
+}
+
+.ontario-text-block th {
+  background-color: var(--ontario-colour-grey-lighter, #f5f5f5);
+  font-weight: 700;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextBlock/sfGpsDsCaOnFormTextBlock.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextBlock/sfGpsDsCaOnFormTextBlock.html
@@ -1,0 +1,34 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System - Text Block for OmniStudio
+  
+  This template renders rich text/HTML content with Ontario DS typography styling.
+  Uses lwc:dom="manual" to allow dynamic HTML injection via replaceInnerHtml.
+  
+  Compliance:
+  - LWR: Compatible (lwc:dom="manual" for dynamic content)
+  - LWS: Compatible (uses replaceInnerHtml helper)
+  - Ontario DS: Applies ontario-text-block class for typography
+  - WCAG 2.1 AA: 
+    - Semantic HTML preserved from source content
+    - Proper heading hierarchy supported
+    - Links and interactive elements remain accessible
+
+  Template Notes:
+  - The sfGpsDsCaOnMerge class is used as a selector for content injection
+  - ontario-text-block applies Ontario DS typography (font, line-height, spacing)
+  - lwc:dom="manual" is required for dynamic HTML content
+-->
+<template>
+  <!-- 
+    WCAG 1.3.1: Content region for text block.
+    role="region" with aria-label provides landmark for screen reader navigation.
+    This allows users to skip to or past text blocks when navigating by landmarks.
+  -->
+  <div
+    class="ontario-text-block sfGpsDsCaOnMerge"
+    role="region"
+    aria-label="Information content"
+    lwc:dom="manual"
+  ></div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextBlock/sfGpsDsCaOnFormTextBlock.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextBlock/sfGpsDsCaOnFormTextBlock.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import SfGpsDsFormTextBlock from "c/sfGpsDsFormTextBlock";
+import { omniGetMergedField } from "c/sfGpsDsOmniHelpers";
+import { replaceInnerHtml } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormTextBlock.html";
+
+/**
+ * @slot Text Block
+ * @description Ontario Design System Text Block for OmniStudio forms.
+ * Displays rich text/HTML content with merge field support and Ontario DS typography.
+ *
+ * This component overrides the standard OmniScript Text Block element to provide
+ * Ontario Design System styling while maintaining full merge field functionality.
+ *
+ * ## Architecture
+ * - Extends: SfGpsDsFormTextBlock (base form text block)
+ * - Renders: HTML content with merge fields replaced
+ * - Styling: Ontario DS typography via caon-scope class
+ *
+ * ## OmniScript Configuration
+ * In OmniScript Designer, configure the Text Block:
+ * - Text: HTML content with optional merge fields (e.g., %FirstName%)
+ * - Supports all standard HTML tags and inline styles
+ * - Merge fields are replaced at runtime with data values
+ *
+ * ## Merge Field Examples
+ * - %FirstName% - Simple field reference
+ * - %Address:Street% - Nested field reference
+ * - %Items[0]:Name% - Array element reference
+ *
+ * ## OmniScript Registration
+ * Register in your OmniScript LWC override:
+ * ```javascript
+ * import sfGpsDsCaOnFormTextBlock from "c/sfGpsDsCaOnFormTextBlock";
+ *
+ * static elementTypeToLwcConstructorMap = {
+ *   ...OmniscriptBaseOsrt.elementTypeToLwcConstructorMap,
+ *   "Text Block": sfGpsDsCaOnFormTextBlock,
+ * };
+ * ```
+ *
+ * Compliance:
+ * - LWR: Uses lwc:dom="manual" for dynamic HTML injection
+ * - LWS: Uses replaceInnerHtml helper for safe HTML insertion
+ * - Ontario DS: Applies ontario-text-block styling
+ * - WCAG 2.1 AA: Semantic HTML preserved, proper heading hierarchy
+ */
+export default class SfGpsDsCaOnFormTextBlock extends SfGpsDsFormTextBlock {
+  /* ========================================
+   * CONSTANTS
+   * ======================================== */
+
+  /**
+   * CSS selector for the merge field container element.
+   * @type {string}
+   */
+  static MERGE_QUERY_SELECTOR = ".sfGpsDsCaOnMerge";
+
+  /* ========================================
+   * LIFECYCLE METHODS
+   * ======================================== */
+
+  /**
+   * Renders the Ontario-specific template.
+   * @returns {Object} The imported HTML template
+   */
+  render() {
+    return tmpl;
+  }
+
+  /**
+   * Initializes the component when added to DOM.
+   * Sets up Ontario DS-specific styling classes.
+   */
+  connectedCallback() {
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    // Add Ontario DS scope class for CSS isolation
+    this.classList.add("caon-scope");
+  }
+
+  /**
+   * Called after render to inject merged HTML content.
+   * Uses replaceInnerHtml for safe DOM manipulation.
+   */
+  renderedCallback() {
+    const element = this.template.querySelector(
+      SfGpsDsCaOnFormTextBlock.MERGE_QUERY_SELECTOR
+    );
+
+    if (element && this.jsonDef?.propSetMap?.text) {
+      // Get the text content with merge fields replaced
+      const mergedContent = omniGetMergedField(
+        this,
+        this.jsonDef.propSetMap.text
+      );
+
+      // Safely inject the HTML content
+      replaceInnerHtml(element, mergedContent);
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextBlock/sfGpsDsCaOnFormTextBlock.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextBlock/sfGpsDsCaOnFormTextBlock.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Text Block for OmniStudio standard runtime forms. Displays rich text/HTML content with merge field support. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextarea/sfGpsDsCaOnFormTextarea.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextarea/sfGpsDsCaOnFormTextarea.css
@@ -1,0 +1,66 @@
+.ontario-form-group {
+  margin-bottom: 1.5rem;
+}
+.ontario-label {
+  display: block;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+}
+.ontario-label__flag {
+  font-weight: 400;
+}
+.ontario-hint {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+.ontario-textarea {
+  display: block;
+  width: 100%;
+  max-width: 48rem;
+  padding: 0.625rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background-color: #fff;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+  resize: vertical;
+  font-family: inherit;
+}
+.ontario-textarea:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 0;
+  box-shadow: 0 0 0 4px #009ade;
+}
+.ontario-textarea:disabled {
+  background-color: #e6e6e6;
+  border-color: #666;
+  color: #666;
+  cursor: not-allowed;
+}
+.ontario-textarea__error {
+  border-color: #cd0000;
+}
+.ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #cd0000;
+  margin-bottom: 0.5rem;
+}
+.ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  fill: #cd0000;
+}
+.ontario-error-messaging__content {
+  font-size: 1rem;
+  line-height: 1.5;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextarea/sfGpsDsCaOnFormTextarea.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextarea/sfGpsDsCaOnFormTextarea.html
@@ -1,0 +1,62 @@
+<!-- sldsValidatorIgnore -->
+<template>
+  <div class="ontario-form-group">
+    <label class="ontario-label" for={inputId}>
+      {mergedLabel}
+      <span lwc:if={showRequiredFlag} class="ontario-label__flag"
+        >(required)</span
+      >
+      <span lwc:if={showOptionalFlag} class="ontario-label__flag"
+        >(optional)</span
+      >
+    </label>
+
+    <p lwc:if={mergedHelpText} id={hintId} class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <div
+      lwc:if={sfGpsDsIsError}
+      id={errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <textarea
+      id={inputId}
+      name={_name}
+      class={computedInputClassName}
+      placeholder={mergedPlaceholder}
+      disabled={_propSetMap.disabled}
+      readonly={_propSetMap.readOnly}
+      required={_propSetMap.required}
+      aria-required={computedAriaRequired}
+      rows={computedRows}
+      minlength={_minLength}
+      maxlength={_maxLength}
+      aria-describedby={computedAriaDescribedBy}
+      aria-invalid={computedAriaInvalid}
+      data-omni-input
+      oninput={handleInput}
+      onchange={handleChange}
+      onblur={handleBlur}
+    >
+{elementValue}</textarea
+    >
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextarea/sfGpsDsCaOnFormTextarea.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextarea/sfGpsDsCaOnFormTextarea.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import SfGpsDsFormTextarea from "c/sfGpsDsFormTextarea";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormTextarea.html";
+
+export default class SfGpsDsCaOnFormTextarea extends SfGpsDsFormTextarea {
+  _uniqueId = `textarea-${Math.random().toString(36).substring(2, 11)}`;
+
+  get inputId() {
+    return `${this._uniqueId}-input`;
+  }
+  get hintId() {
+    return `${this._uniqueId}-hint`;
+  }
+  get errorId() {
+    return `${this._uniqueId}-error`;
+  }
+  get showRequiredFlag() {
+    return this._propSetMap?.required === true;
+  }
+  get showOptionalFlag() {
+    return this._propSetMap?.optional === true && !this._propSetMap?.required;
+  }
+
+  get computedRows() {
+    return this._propSetMap?.rows || 5;
+  }
+
+  get computedInputClassName() {
+    return computeClass({
+      "ontario-textarea": true,
+      "ontario-textarea__error": this.sfGpsDsIsError
+    });
+  }
+  get computedAriaDescribedBy() {
+    return computeClass({
+      [this.hintId]: this.mergedHelpText,
+      [this.errorId]: this.sfGpsDsIsError
+    });
+  }
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+  get computedAriaRequired() {
+    return this._propSetMap?.required ? "true" : "false";
+  }
+
+  focusInput() {
+    try {
+      const textarea = this.template.querySelector("textarea");
+      if (textarea) textarea.focus();
+    } catch {
+      /* fail silently */
+    }
+  }
+
+  render() {
+    return tmpl;
+  }
+  connectedCallback() {
+    if (super.connectedCallback) super.connectedCallback();
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextarea/sfGpsDsCaOnFormTextarea.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTextarea/sfGpsDsCaOnFormTextarea.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTime/sfGpsDsCaOnFormTime.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTime/sfGpsDsCaOnFormTime.css
@@ -1,0 +1,64 @@
+.ontario-form-group {
+  margin-bottom: 1.5rem;
+}
+.ontario-label {
+  display: block;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+}
+.ontario-label__flag {
+  font-weight: 400;
+}
+.ontario-hint {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+.ontario-input {
+  display: block;
+  width: auto;
+  max-width: 48rem;
+  padding: 0.625rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background-color: #fff;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+}
+.ontario-input:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 0;
+  box-shadow: 0 0 0 4px #009ade;
+}
+.ontario-input:disabled {
+  background-color: #e6e6e6;
+  border-color: #666;
+  color: #666;
+  cursor: not-allowed;
+}
+.ontario-input__error {
+  border-color: #cd0000;
+}
+.ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #cd0000;
+  margin-bottom: 0.5rem;
+}
+.ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  fill: #cd0000;
+}
+.ontario-error-messaging__content {
+  font-size: 1rem;
+  line-height: 1.5;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTime/sfGpsDsCaOnFormTime.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTime/sfGpsDsCaOnFormTime.html
@@ -1,0 +1,57 @@
+<!-- sldsValidatorIgnore -->
+<template>
+  <div class="ontario-form-group">
+    <label class="ontario-label" for={inputId}>
+      {mergedLabel}
+      <span lwc:if={showRequiredFlag} class="ontario-label__flag"
+        >(required)</span
+      >
+      <span lwc:if={showOptionalFlag} class="ontario-label__flag"
+        >(optional)</span
+      >
+    </label>
+
+    <p lwc:if={mergedHelpText} id={hintId} class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <div
+      lwc:if={sfGpsDsIsError}
+      id={errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <input
+      type="time"
+      id={inputId}
+      name={_name}
+      class={computedInputClassName}
+      value={elementValue}
+      disabled={_propSetMap.disabled}
+      readonly={_propSetMap.readOnly}
+      required={_propSetMap.required}
+      aria-required={computedAriaRequired}
+      aria-describedby={computedAriaDescribedBy}
+      aria-invalid={computedAriaInvalid}
+      data-omni-input
+      onchange={handleChange}
+      onblur={handleBlur}
+    />
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTime/sfGpsDsCaOnFormTime.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTime/sfGpsDsCaOnFormTime.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import SfGpsDsFormTime from "c/sfGpsDsFormTime";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormTime.html";
+
+export default class SfGpsDsCaOnFormTime extends SfGpsDsFormTime {
+  _uniqueId = `time-${Math.random().toString(36).substring(2, 11)}`;
+
+  get inputId() {
+    return `${this._uniqueId}-input`;
+  }
+  get hintId() {
+    return `${this._uniqueId}-hint`;
+  }
+  get errorId() {
+    return `${this._uniqueId}-error`;
+  }
+  get showRequiredFlag() {
+    return this._propSetMap?.required === true;
+  }
+  get showOptionalFlag() {
+    return this._propSetMap?.optional === true && !this._propSetMap?.required;
+  }
+  get computedInputClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "ontario-input__error": this.sfGpsDsIsError
+    });
+  }
+  get computedAriaDescribedBy() {
+    return computeClass({
+      [this.hintId]: this.mergedHelpText,
+      [this.errorId]: this.sfGpsDsIsError
+    });
+  }
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+  get computedAriaRequired() {
+    return this._propSetMap?.required ? "true" : "false";
+  }
+
+  render() {
+    return tmpl;
+  }
+  connectedCallback() {
+    if (super.connectedCallback) super.connectedCallback();
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTime/sfGpsDsCaOnFormTime.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTime/sfGpsDsCaOnFormTime.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Time input for OmniStudio standard runtime forms. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTypeahead/sfGpsDsCaOnFormTypeahead.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTypeahead/sfGpsDsCaOnFormTypeahead.css
@@ -1,0 +1,107 @@
+/*
+ * Ontario Design System - Typeahead Component Styles
+ */
+
+.sfgpsdscaon-typeahead {
+  position: relative;
+}
+
+.sfgpsdscaon-typeahead-container {
+  position: relative;
+}
+
+.sfgpsdscaon-typeahead__form-element {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.sfgpsdscaon-typeahead__input {
+  padding-right: 2.5rem;
+}
+
+.sfgpsdscaon-typeahead__icon {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  pointer-events: none;
+  fill: var(--ontario-greyscale-40, #666666);
+}
+
+.sfgpsdscaon-typeahead__loader {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+/* Dropdown styles - shared with Lookup */
+.sfgpsdscaon-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 7001;
+  max-height: 200px;
+  overflow-y: auto;
+  background: var(--ontario-colour-white, #ffffff);
+  border: 2px solid var(--ontario-colour-black, #1a1a1a);
+  border-top: none;
+  border-radius: 0 0 4px 4px;
+  display: none;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.sfgpsdscaon-dropdown--open {
+  display: block;
+}
+
+.sfgpsdscaon-listbox {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sfgpsdscaon-listbox__item {
+  margin: 0;
+  padding: 0;
+}
+
+.sfgpsdscaon-listbox__option {
+  display: block;
+  padding: 0.75rem 1rem;
+  text-decoration: none;
+  color: var(--ontario-colour-black, #1a1a1a);
+  cursor: pointer;
+  border-bottom: 1px solid var(--ontario-greyscale-10, #e0e0e0);
+}
+
+.sfgpsdscaon-listbox__option:last-child {
+  border-bottom: none;
+}
+
+.sfgpsdscaon-listbox__option:hover,
+.sfgpsdscaon-listbox__option.sfgpsdscaon-has-focus {
+  background-color: var(--ontario-colour-info-light, #e8f4fd);
+}
+
+.sfgpsdscaon-listbox__option:focus {
+  /* ODS-compliant focus indicator */
+  background-color: var(--ontario-colour-info-light, #e8f4fd);
+  outline: 4px solid transparent;
+  box-shadow: inset 0 0 0 4px var(--ontario-colour-focus, #009adb);
+}
+
+.sfgpsdscaon-listbox__option[aria-selected="true"] {
+  background-color: var(--ontario-colour-link, #0066cc);
+  color: var(--ontario-colour-white, #ffffff);
+}
+
+/* Open state indicator */
+.sfgpsdscaon-is-open .sfgpsdscaon-typeahead__input {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTypeahead/sfGpsDsCaOnFormTypeahead.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTypeahead/sfGpsDsCaOnFormTypeahead.html
@@ -1,0 +1,144 @@
+<!-- sldsValidatorIgnore -->
+<!--
+  Ontario Design System - Typeahead for OmniStudio
+  
+  Provides autocomplete functionality with remote data source support.
+  
+  Compliance:
+  - LWR: Compatible (Light DOM pattern)
+  - LWS: Compatible (no restricted APIs)
+  - Ontario DS: Uses Ontario form field styling
+  - WCAG 2.1 AA: 
+    - Proper ARIA combobox pattern
+    - aria-expanded, aria-controls, aria-activedescendant
+    - Keyboard navigation
+    - Screen reader announcements
+-->
+<template>
+  <div class="ontario-form-group sfgpsdscaon-typeahead">
+    <!-- Label -->
+    <label class={computedLabelClassName} for="typeaheadId">
+      {mergedLabel}
+      <span lwc:if={showFlag} class="ontario-label__flag">({flagText})</span>
+    </label>
+
+    <!-- Hint text -->
+    <p lwc:if={mergedHelpText} id="helper" class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <!-- Screen reader announcements for results (AODA) -->
+    <div
+      class="ontario-show-for-sr"
+      aria-live="polite"
+      aria-atomic="true"
+      role="status"
+    >
+      <span lwc:if={_showOptions}>{resultsAnnouncement}</span>
+    </div>
+
+    <!-- Typeahead container -->
+    <div class="sfgpsdscaon-typeahead-container">
+      <div class="sfgpsdscaon-typeahead__form-element" role="none">
+        <!-- Input field -->
+        <input
+          class={computedInputClassName}
+          type="text"
+          id="typeaheadId"
+          placeholder={mergedPlaceholder}
+          value={elementValue}
+          disabled={_propSetMap.readOnly}
+          readonly={_propSetMap.readOnly}
+          required={_propSetMap.required}
+          aria-required={_propSetMap.required}
+          minlength={_propSetMap.minLength}
+          maxlength={_propSetMap.maxLength}
+          aria-invalid={sfGpsDsIsError}
+          aria-expanded={_showOptions}
+          aria-haspopup="listbox"
+          aria-controls="typeahead-listbox"
+          aria-activedescendant={computedAriaActiveDescendant}
+          aria-describedby={computedAriaDescribedBy}
+          aria-autocomplete="list"
+          role="combobox"
+          autocomplete="off"
+          data-omni-input
+          onblur={handleBlur}
+          onfocus={handleInputChange}
+          onkeydown={handleInputKeyDown}
+          onkeyup={handleInputChange}
+        />
+
+        <!-- Search icon (shown when not loading) -->
+        <svg
+          class="sfgpsdscaon-typeahead__icon"
+          aria-hidden="true"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+          />
+        </svg>
+      </div>
+
+      <!-- Dropdown list -->
+      <div
+        lwc:if={hasOptions}
+        class={computedDropdownClassName}
+        id="typeahead-listbox"
+        role="listbox"
+      >
+        <ul class="sfgpsdscaon-listbox" role="presentation">
+          <template
+            for:each={decoratedOptions}
+            for:item="optionItem"
+            for:index="optionIndex"
+          >
+            <li
+              key={optionItem.key}
+              class="sfgpsdscaon-listbox__item"
+              role="presentation"
+            >
+              <div
+                class="sfgpsdscaon-listbox__option"
+                id={optionItem.id}
+                role="option"
+                tabindex="0"
+                data-option-index={optionIndex}
+                onclick={handleOptionSelect}
+                onmouseover={handleOptionFocus}
+                onkeydown={handleOptionSelect}
+              >
+                {optionItem.label}
+              </div>
+            </li>
+          </template>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Error message -->
+    <div
+      lwc:if={sfGpsDsIsError}
+      class="ontario-error-messaging"
+      aria-live="assertive"
+      role="alert"
+      id="errorMessageBlock"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTypeahead/sfGpsDsCaOnFormTypeahead.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTypeahead/sfGpsDsCaOnFormTypeahead.js
@@ -1,0 +1,528 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import SfGpsDsFormTypeahead from "c/sfGpsDsFormTypeahead";
+import { computeClass } from "c/sfGpsDsHelpers";
+import { omniGetMergedField } from "c/sfGpsDsOmniHelpers";
+import { Logger } from "c/sfGpsDsCaOnDebugUtils";
+import tmpl from "./sfGpsDsCaOnFormTypeahead.html";
+
+/**
+ * Logger instance for this component.
+ * Enable debug output by setting window.sfGpsDsCaOnDebug = true in console.
+ * @type {Logger}
+ */
+const log = new Logger("SfGpsDsCaOnFormTypeahead");
+
+/**
+ * CSS class applied when dropdown is open.
+ * @type {string}
+ */
+const THEME_IS_OPEN_CLASSNAME = "sfgpsdscaon-is-open";
+
+/**
+ * CSS class applied to the currently focused option.
+ * @type {string}
+ */
+const THEME_HAS_FOCUS_CLASSNAME = "sfgpsdscaon-has-focus";
+
+/**
+ * @slot Typeahead
+ * @description Ontario Design System Typeahead for OmniStudio forms.
+ * Provides autocomplete functionality with remote data source support.
+ *
+ * ## Key Inherited Properties (from OmniscriptTypeahead via SfGpsDsFormTypeahead)
+ * - `options` {Array} - Available options from remote source
+ * - `elementValue` {string} - Current input value
+ * - `_isEditMode` {boolean} - Whether in edit mode (shows child elements)
+ * - `errorMessage` {string} - Error message from remote call
+ *
+ * ## Key Inherited Methods (from OmniscriptTypeahead)
+ * - `handleTypeahead(event)` - Debounced handler for keyup, triggers remote search
+ * - `handleSelect(event)` - Handles option selection from dropdown
+ * - `handleBlur(event)` - Handles blur, triggers validation
+ * - `toggleEditMode()` - Toggles edit mode for child elements
+ *
+ * ## Compliance
+ * - **LWR**: Uses Light DOM parent component
+ * - **LWS**: No eval(), proper namespace imports
+ * - **Ontario DS**: Uses Ontario form field styling
+ * - **WCAG 2.1 AA**: Proper ARIA combobox pattern, keyboard navigation
+ *
+ * @see {@link sfGpsDsCaOnFormLookup} Similar component for static lookups
+ */
+export default class SfGpsDsCaOnFormTypeahead extends SfGpsDsFormTypeahead {
+  /**
+   * Track whether dropdown is showing.
+   * @type {boolean}
+   */
+  _showOptions = false;
+
+  /**
+   * Track loading state during remote calls.
+   * @type {boolean}
+   */
+  _isLoading = false;
+
+  /**
+   * Index of currently highlighted option for keyboard navigation.
+   * @type {number}
+   */
+  _highlightIndex = -1;
+
+  /* ========================================
+   * COMPUTED PROPERTIES - ERROR STATE
+   * Validation error display - these are not in base SfGpsDsFormTypeahead
+   * ======================================== */
+
+  /**
+   * Returns true if the field has a validation error.
+   * Checks both standard validation and custom validation from SetErrors.
+   *
+   * @returns {boolean} True if field is invalid
+   * @template-binding: aria-invalid={sfGpsDsIsError}
+   */
+  get sfGpsDsIsError() {
+    // Check standard validation state
+    if (this._showValidation && !this.isValid) {
+      return true;
+    }
+    // Check custom validation (from SetErrors action)
+    if (this._sfGpsDsCustomValidation) {
+      return true;
+    }
+    // Check error from remote call
+    if (this.errorMessage) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Returns the error message to display.
+   *
+   * @returns {string|null} Error message or null
+   * @template-binding: {sfGpsDsErrorMessage}
+   */
+  get sfGpsDsErrorMessage() {
+    if (this.errorMessage) {
+      return omniGetMergedField(this, this.errorMessage);
+    }
+    if (this.validationMessage) {
+      return omniGetMergedField(this, this.validationMessage);
+    }
+    return null;
+  }
+
+  /* ========================================
+   * COMPUTED PROPERTIES - CSS CLASSES
+   * Used for Ontario DS styling in templates
+   * ======================================== */
+
+  /**
+   * Computes CSS classes for the label element.
+   *
+   * @returns {string} Space-separated CSS classes
+   * @template-binding: <label class={computedLabelClassName}>
+   */
+  get computedLabelClassName() {
+    return computeClass({
+      "ontario-label": true,
+      "ontario-label--required": this._propSetMap.required
+    });
+  }
+
+  /**
+   * Computes CSS classes for the input element.
+   *
+   * @returns {string} Space-separated CSS classes
+   * @template-binding: <input class={computedInputClassName}>
+   */
+  get computedInputClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "sfgpsdscaon-typeahead__input": true,
+      "ontario-input__error": this.sfGpsDsIsError
+    });
+  }
+
+  /**
+   * Determines if required/optional flag should display.
+   *
+   * @returns {boolean} True if flag should show
+   * @template-binding: <span lwc:if={showFlag}>
+   */
+  get showFlag() {
+    return this._propSetMap?.required || this._propSetMap?.optional;
+  }
+
+  /**
+   * Returns the flag text ("required" or "optional").
+   *
+   * @returns {string} Flag text
+   * @template-binding: ({flagText})
+   */
+  get flagText() {
+    if (this._propSetMap?.required) return "required";
+    if (this._propSetMap?.optional) return "optional";
+    return "";
+  }
+
+  /**
+   * Computes aria-describedby for accessibility.
+   *
+   * @returns {string|null} Space-separated element IDs
+   * @template-binding: aria-describedby={computedAriaDescribedBy}
+   */
+  get computedAriaDescribedBy() {
+    const ids = [];
+    if (this.mergedHelpText) ids.push("helper");
+    if (this.sfGpsDsIsError) ids.push("errorMessageBlock");
+    return ids.length > 0 ? ids.join(" ") : null;
+  }
+
+  /**
+   * Computes aria-activedescendant for the currently highlighted option.
+   * AODA/WCAG 4.1.2: Announces active option to screen readers during keyboard navigation.
+   *
+   * @returns {string|null} ID of highlighted option or null
+   * @template-binding: aria-activedescendant={computedAriaActiveDescendant}
+   */
+  get computedAriaActiveDescendant() {
+    if (
+      this._showOptions &&
+      this._highlightIndex >= 0 &&
+      this._highlightIndex < (this.options?.length || 0)
+    ) {
+      return `typeahead-option-${this._highlightIndex}`;
+    }
+    return null;
+  }
+
+  /**
+   * Returns the number of available options for screen reader announcement.
+   *
+   * @returns {number} Number of options
+   * @template-binding: Used in live region
+   */
+  get optionCount() {
+    return this.options?.length || 0;
+  }
+
+  /**
+   * Returns announcement text for screen readers when results are available.
+   * AODA/WCAG: Provides dynamic result count for assistive technology.
+   *
+   * @returns {string} Announcement text
+   * @template-binding: Used in aria-live region
+   */
+  get resultsAnnouncement() {
+    if (this._isLoading) {
+      return "Searching...";
+    }
+    const count = this.optionCount;
+    if (count === 0) {
+      return "No results found";
+    }
+    return `${count} result${count === 1 ? "" : "s"} available. Use up and down arrows to navigate.`;
+  }
+
+  /**
+   * Computes CSS classes for the dropdown container.
+   *
+   * @returns {string} Space-separated CSS classes
+   * @template-binding: <div class={computedDropdownClassName}>
+   */
+  get computedDropdownClassName() {
+    return computeClass({
+      "sfgpsdscaon-dropdown": true,
+      "sfgpsdscaon-dropdown--open": this._showOptions
+    });
+  }
+
+  /**
+   * Returns true if options array has items.
+   *
+   * @returns {boolean} True if options exist
+   * @template-binding: <div lwc:if={hasOptions}>
+   */
+  get hasOptions() {
+    return this.options && this.options.length > 0;
+  }
+
+  /**
+   * Transforms options for template rendering.
+   * OmniStudio typeahead uses `name` for display, we map it to `label` for consistency.
+   *
+   * @returns {Array} Decorated options with key, id, and label
+   * @template-binding: Used in for:each iteration
+   */
+  get decoratedOptions() {
+    return (this.options || []).map((opt, index) => {
+      // Handle both string options and object options
+      const optObj = typeof opt === "string" ? { name: opt } : opt;
+      return {
+        ...optObj,
+        key: optObj.key || index,
+        id: `typeahead-option-${index}`,
+        // Use `name` from OmniStudio options, fallback to label or value
+        label: optObj.name || optObj.label || optObj.value || ""
+      };
+    });
+  }
+
+  /* ========================================
+   * DROPDOWN BEHAVIOR
+   * Show/hide options and manage focus
+   * ======================================== */
+
+  /**
+   * Opens the dropdown and applies open state class.
+   */
+  showOptions() {
+    this._showOptions = true;
+    const triggerEl = this.template.querySelector(".sfgpsdscaon-typeahead");
+    if (triggerEl) {
+      triggerEl.classList.add(THEME_IS_OPEN_CLASSNAME);
+    }
+  }
+
+  /**
+   * Closes the dropdown and removes open state class.
+   */
+  hideOptions() {
+    this._showOptions = false;
+    this._highlightIndex = -1;
+    const triggerEl = this.template.querySelector(".sfgpsdscaon-typeahead");
+    if (triggerEl) {
+      triggerEl.classList.remove(THEME_IS_OPEN_CLASSNAME);
+    }
+  }
+
+  /* ========================================
+   * EVENT HANDLERS
+   * Handle user interactions, delegate to parent where needed
+   * ======================================== */
+
+  /**
+   * Handles option selection from the dropdown.
+   * Delegates to parent's handleSelect for proper OmniScript integration.
+   *
+   * @param {Event} event - Click or keydown event on option
+   */
+  handleOptionSelect(event) {
+    log.enter("handleOptionSelect", { type: event.type, key: event.key });
+
+    // Only handle click or Enter key
+    if (event.type === "keydown" && event.key !== "Enter") {
+      log.exit("handleOptionSelect", "ignored - not Enter key");
+      return;
+    }
+
+    event.preventDefault();
+
+    const index = parseInt(
+      event.currentTarget.getAttribute("data-option-index"),
+      10
+    );
+    const option = this.options[index];
+
+    log.debug("Option selected", { index, option });
+
+    if (option) {
+      // Get the value to apply - OmniStudio uses `name` for the value
+      const value = typeof option === "string" ? option : option.name;
+
+      log.debug("Applying value to OmniScript", { value });
+
+      // Update OmniScript data through parent's applyCallResp
+      try {
+        this.applyCallResp(value);
+        log.debug("Value applied successfully");
+      } catch (error) {
+        log.error("Failed to apply value", error);
+      }
+
+      // Clear options to close dropdown
+      this.options = [];
+    }
+
+    this.hideOptions();
+    log.exit("handleOptionSelect");
+  }
+
+  /**
+   * Handles mouse hover on options for visual focus.
+   *
+   * @param {Event} event - Mouseover event
+   */
+  handleOptionFocus(event) {
+    const options = this.template.querySelectorAll('[role="option"]');
+    options.forEach((opt) => opt.classList.remove(THEME_HAS_FOCUS_CLASSNAME));
+
+    event.currentTarget.classList.add(THEME_HAS_FOCUS_CLASSNAME);
+    this._highlightIndex = parseInt(
+      event.currentTarget.getAttribute("data-option-index"),
+      10
+    );
+  }
+
+  /**
+   * Handles keyboard navigation in dropdown.
+   *
+   * @param {KeyboardEvent} event - Keydown event on input
+   */
+  handleInputKeyDown(event) {
+    log.trace("handleInputKeyDown", {
+      key: event.key,
+      showOptions: this._showOptions
+    });
+
+    switch (event.key) {
+      case "Escape":
+        log.debug("Keyboard: Escape - closing dropdown");
+        this.hideOptions();
+        break;
+
+      case "ArrowDown":
+        event.preventDefault();
+        if (!this._showOptions && this.hasOptions) {
+          log.debug("Keyboard: ArrowDown - opening dropdown");
+          this.showOptions();
+        }
+        this._highlightIndex = Math.min(
+          this._highlightIndex + 1,
+          this.options.length - 1
+        );
+        log.stateChange(
+          "_highlightIndex",
+          this._highlightIndex - 1,
+          this._highlightIndex
+        );
+        this.updateHighlight();
+        break;
+
+      case "ArrowUp": {
+        event.preventDefault();
+        const prevIndex = this._highlightIndex;
+        this._highlightIndex = Math.max(this._highlightIndex - 1, 0);
+        log.stateChange("_highlightIndex", prevIndex, this._highlightIndex);
+        this.updateHighlight();
+        break;
+      }
+
+      case "Enter":
+        if (this._showOptions && this._highlightIndex >= 0) {
+          event.preventDefault();
+          const option = this.options[this._highlightIndex];
+          log.debug("Keyboard: Enter - selecting option", {
+            index: this._highlightIndex,
+            option
+          });
+          if (option) {
+            const value = typeof option === "string" ? option : option.name;
+            try {
+              this.applyCallResp(value);
+            } catch (error) {
+              log.error("Failed to apply selection via Enter", error);
+            }
+            this.options = [];
+          }
+          this.hideOptions();
+        }
+        break;
+
+      default:
+        // Let other keys pass through
+        break;
+    }
+  }
+
+  /**
+   * Updates visual highlight on options based on _highlightIndex.
+   */
+  updateHighlight() {
+    const options = this.template.querySelectorAll('[role="option"]');
+    options.forEach((opt, idx) => {
+      if (idx === this._highlightIndex) {
+        opt.classList.add(THEME_HAS_FOCUS_CLASSNAME);
+        opt.scrollIntoView({ block: "nearest" });
+      } else {
+        opt.classList.remove(THEME_HAS_FOCUS_CLASSNAME);
+      }
+    });
+  }
+
+  /**
+   * Handles input changes and triggers remote search.
+   * Delegates to parent's handleTypeahead for debounced remote calls.
+   *
+   * @param {Event} event - Input or focus event
+   */
+  handleInputChange() {
+    // Parent's handleTypeahead is bound to keyup and handles debounced search
+    // We call it via the event system
+    if (this.hasOptions) {
+      this.showOptions();
+    }
+  }
+
+  /* ========================================
+   * LIFECYCLE METHODS
+   * ======================================== */
+
+  /**
+   * Returns the Ontario DS template.
+   *
+   * @returns {Object} Template to render
+   * @override
+   */
+  render() {
+    return tmpl;
+  }
+
+  /**
+   * Initializes component with Ontario DS classes.
+   *
+   * @override
+   */
+  connectedCallback() {
+    log.enter("connectedCallback");
+    log.timeStart("initialization");
+
+    if (super.connectedCallback) {
+      super.connectedCallback();
+    }
+
+    this._readOnlyClass = "sfgpsdscaon-read-only";
+    this._showOptions = false;
+    this._highlightIndex = -1;
+    this.classList.add("caon-scope");
+
+    log.debug("Component initialized", {
+      label: this._propSetMap?.label,
+      required: this._propSetMap?.required,
+      dataJson: this._propSetMap?.dataJson ? "configured" : "none"
+    });
+
+    log.timeEnd("initialization");
+    log.exit("connectedCallback");
+  }
+
+  /**
+   * Cleanup when component is removed.
+   *
+   * @override
+   */
+  disconnectedCallback() {
+    log.debug("Component disconnecting");
+
+    if (super.disconnectedCallback) {
+      super.disconnectedCallback();
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTypeahead/sfGpsDsCaOnFormTypeahead.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormTypeahead/sfGpsDsCaOnFormTypeahead.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System Typeahead for OmniStudio standard runtime forms. Provides autocomplete with remote data source support. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormUrl/sfGpsDsCaOnFormUrl.css
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormUrl/sfGpsDsCaOnFormUrl.css
@@ -1,0 +1,64 @@
+.ontario-form-group {
+  margin-bottom: 1.5rem;
+}
+.ontario-label {
+  display: block;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+}
+.ontario-label__flag {
+  font-weight: 400;
+}
+.ontario-hint {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #4d4d4d;
+  margin-bottom: 0.5rem;
+  margin-top: 0;
+}
+.ontario-input {
+  display: block;
+  width: 100%;
+  max-width: 48rem;
+  padding: 0.625rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background-color: #fff;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+}
+.ontario-input:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 0;
+  box-shadow: 0 0 0 4px #009ade;
+}
+.ontario-input:disabled {
+  background-color: #e6e6e6;
+  border-color: #666;
+  color: #666;
+  cursor: not-allowed;
+}
+.ontario-input__error {
+  border-color: #cd0000;
+}
+.ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: #cd0000;
+  margin-bottom: 0.5rem;
+}
+.ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  fill: #cd0000;
+}
+.ontario-error-messaging__content {
+  font-size: 1rem;
+  line-height: 1.5;
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormUrl/sfGpsDsCaOnFormUrl.html
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormUrl/sfGpsDsCaOnFormUrl.html
@@ -1,0 +1,60 @@
+<!-- sldsValidatorIgnore -->
+<template>
+  <div class="ontario-form-group">
+    <label class="ontario-label" for={inputId}>
+      {mergedLabel}
+      <span lwc:if={showRequiredFlag} class="ontario-label__flag"
+        >(required)</span
+      >
+      <span lwc:if={showOptionalFlag} class="ontario-label__flag"
+        >(optional)</span
+      >
+    </label>
+
+    <p lwc:if={mergedHelpText} id={hintId} class="ontario-hint">
+      {mergedHelpText}
+    </p>
+
+    <div
+      lwc:if={sfGpsDsIsError}
+      id={errorId}
+      class="ontario-error-messaging"
+      role="alert"
+      aria-live="assertive"
+    >
+      <svg
+        class="ontario-icon"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+        />
+      </svg>
+      <span class="ontario-error-messaging__content"
+        >{sfGpsDsErrorMessage}</span
+      >
+    </div>
+
+    <input
+      type="url"
+      id={inputId}
+      name={_name}
+      class={computedInputClassName}
+      value={elementValue}
+      placeholder={mergedPlaceholder}
+      disabled={_propSetMap.disabled}
+      readonly={_propSetMap.readOnly}
+      required={_propSetMap.required}
+      aria-required={computedAriaRequired}
+      autocomplete={_autocomplete}
+      aria-describedby={computedAriaDescribedBy}
+      aria-invalid={computedAriaInvalid}
+      data-omni-input
+      oninput={handleInput}
+      onchange={handleChange}
+      onblur={handleBlur}
+    />
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormUrl/sfGpsDsCaOnFormUrl.js
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormUrl/sfGpsDsCaOnFormUrl.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import SfGpsDsFormUrl from "c/sfGpsDsFormUrl";
+import { computeClass } from "c/sfGpsDsHelpers";
+import tmpl from "./sfGpsDsCaOnFormUrl.html";
+
+export default class SfGpsDsCaOnFormUrl extends SfGpsDsFormUrl {
+  _uniqueId = `url-${Math.random().toString(36).substring(2, 11)}`;
+
+  get inputId() {
+    return `${this._uniqueId}-input`;
+  }
+  get hintId() {
+    return `${this._uniqueId}-hint`;
+  }
+  get errorId() {
+    return `${this._uniqueId}-error`;
+  }
+  get showRequiredFlag() {
+    return this._propSetMap?.required === true;
+  }
+  get showOptionalFlag() {
+    return this._propSetMap?.optional === true && !this._propSetMap?.required;
+  }
+  get computedInputClassName() {
+    return computeClass({
+      "ontario-input": true,
+      "ontario-input__error": this.sfGpsDsIsError
+    });
+  }
+  get computedAriaDescribedBy() {
+    return computeClass({
+      [this.hintId]: this.mergedHelpText,
+      [this.errorId]: this.sfGpsDsIsError
+    });
+  }
+  get computedAriaInvalid() {
+    return this.sfGpsDsIsError ? "true" : "false";
+  }
+  get computedAriaRequired() {
+    return this._propSetMap?.required ? "true" : "false";
+  }
+
+  render() {
+    return tmpl;
+  }
+  connectedCallback() {
+    if (super.connectedCallback) super.connectedCallback();
+    this.classList.add("caon-scope");
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormUrl/sfGpsDsCaOnFormUrl.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/omnistudio-standard-runtime-forms/lwc/sfGpsDsCaOnFormUrl/sfGpsDsCaOnFormUrl.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Ontario Design System URL input for OmniStudio standard runtime forms. LWR and LWS compatible. WCAG 2.1 AA compliant.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnAccordionOmni/sfGpsDsCaOnAccordionOmni.css
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnAccordionOmni/sfGpsDsCaOnAccordionOmni.css
@@ -1,0 +1,321 @@
+/*
+ * Ontario Design System - Accordion (OmniStudio)
+ * Shadow DOM compatible styles
+ */
+
+/* ==========================================================================
+   CSS CUSTOM PROPERTIES (Design Tokens)
+   ========================================================================== */
+:host {
+  --ontario-colour-focus: #009adb;
+  --ontario-colour-link: #0066cc;
+  --ontario-colour-link-hover: #00478f;
+  --ontario-colour-link-active: #002142;
+  --ontario-colour-text: #1a1a1a;
+  --ontario-colour-border: #cccccc;
+  --ontario-colour-background: #ffffff;
+  --ontario-colour-background-hover: #f2f2f2;
+  --ontario-font-primary:
+    "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --ontario-font-heading:
+    "Raleway", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+/* ==========================================================================
+   FOCUS STYLES
+   ========================================================================== */
+.ontario-accordion__button--expand-all:focus,
+.ontario-accordion__button:focus {
+  box-shadow: 0 0 0 4px var(--ontario-colour-focus);
+  outline: 4px solid transparent;
+  transition: box-shadow 0.1s ease-in-out;
+}
+
+/* ==========================================================================
+   TYPOGRAPHY
+   ========================================================================== */
+.ontario-accordion__button {
+  font-style: normal;
+  font-weight: 700;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: normal;
+  font-family: var(--ontario-font-heading);
+  font-size: 1.25rem;
+  letter-spacing: 0.03rem;
+  line-height: 1.5;
+  margin: 0 0 0.75rem 0;
+  max-width: 48rem;
+}
+
+@media screen and (min-width: 40em) {
+  .ontario-accordion__button {
+    font-size: 1.5rem;
+    letter-spacing: 0.0313rem;
+    line-height: 1.5;
+  }
+}
+
+/* ==========================================================================
+   ACCORDION CONTAINER
+   ========================================================================== */
+.ontario-accordions__container {
+  max-width: 48rem;
+  width: 100%;
+  font-family: var(--ontario-font-primary);
+}
+
+/* ==========================================================================
+   ACCORDION ITEM
+   ========================================================================== */
+.ontario-accordion {
+  border-top: 2px solid var(--ontario-colour-border);
+}
+
+.ontario-accordion:last-of-type {
+  border-bottom: 2px solid var(--ontario-colour-border);
+}
+
+/* ==========================================================================
+   EXPAND/COLLAPSE ALL CONTROLS
+   ========================================================================== */
+.ontario-accordion__controls {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.ontario-accordion__button,
+.ontario-accordion__button--expand-all {
+  background: none;
+  border: 0;
+  box-sizing: border-box;
+}
+
+.ontario-accordion__button--expand-all {
+  font-size: 1rem;
+  font-family: var(--ontario-font-primary);
+  margin-bottom: 0.5rem;
+  color: var(--ontario-colour-link);
+  cursor: pointer;
+}
+
+.ontario-accordion__button--expand-all:focus,
+.ontario-accordion__button--expand-all:hover {
+  color: var(--ontario-colour-link-hover);
+  text-decoration: underline;
+}
+
+.ontario-accordion__button--expand-all:active {
+  color: var(--ontario-colour-link-active);
+  text-decoration: underline;
+}
+
+.ontario-accordion--expand-close-all {
+  display: none;
+}
+
+.ontario-accordion__controls--active .ontario-accordion--expand-close-all {
+  display: block;
+}
+
+.ontario-accordion__controls--active .ontario-accordion--expand-open-all {
+  display: none;
+}
+
+/* ==========================================================================
+   ACCORDION BUTTON
+   ========================================================================== */
+.ontario-accordion__button {
+  display: flex;
+  align-items: flex-start;
+  color: var(--ontario-colour-link);
+  cursor: pointer;
+  padding: 0.75rem 0.5rem;
+  text-align: left;
+  width: 100%;
+  margin-bottom: 0;
+}
+
+.ontario-accordion__button .ontario-accordion__button-icon--close,
+.ontario-accordion__button .ontario-accordion__button-icon--open {
+  margin-right: 0.5rem;
+  flex-shrink: 0;
+}
+
+.ontario-accordion__button .ontario-icon {
+  width: 1.75rem;
+  height: 1.75rem;
+  fill: currentColor;
+}
+
+.ontario-accordion__button:focus,
+.ontario-accordion__button:hover {
+  background-color: var(--ontario-colour-background-hover);
+  color: var(--ontario-colour-link-hover);
+}
+
+.ontario-accordion__button:focus {
+  box-shadow: 0 0 0 4px var(--ontario-colour-focus) inset;
+}
+
+.ontario-accordion__button:active {
+  color: var(--ontario-colour-link-active);
+}
+
+.ontario-accordion__button-text {
+  flex: 1;
+}
+
+/* ==========================================================================
+   ACCORDION HEADING
+   ========================================================================== */
+.ontario-accordion__heading {
+  margin: 0;
+  padding: 0;
+}
+
+/* ==========================================================================
+   ACCORDION CONTENT
+   ========================================================================== */
+.ontario-accordion__content {
+  display: none;
+  padding: 0.75rem 0.75rem 2rem 0.75rem;
+  margin-left: 0;
+  color: var(--ontario-colour-text);
+  font-family: var(--ontario-font-primary);
+}
+
+@media screen and (min-width: 40em) {
+  .ontario-accordion__content {
+    margin-left: 2rem;
+  }
+}
+
+.ontario-accordion__content * {
+  margin-top: 0;
+  max-width: 48rem;
+  width: 100%;
+}
+
+.ontario-accordion__content ul,
+.ontario-accordion__content ol {
+  max-width: calc(100% - 3rem);
+}
+
+.ontario-accordion__content > :last-child {
+  margin-bottom: 0;
+}
+
+/* ==========================================================================
+   ICON VISIBILITY STATES
+   ========================================================================== */
+.ontario-accordion__button-icon--close,
+.ontario-expander--active .ontario-accordion__button-icon--open {
+  display: none;
+}
+
+.ontario-expander--active ~ .ontario-accordion__content,
+.ontario-expander--active .ontario-accordion__button-icon--close {
+  display: block;
+}
+
+/* ==========================================================================
+   CONTENT OPEN/CLOSED STATES
+   ========================================================================== */
+.ontario-accordion__content--opened {
+  display: block;
+}
+
+.ontario-accordion__content--closed {
+  display: none;
+}
+
+/* ==========================================================================
+   TYPOGRAPHY RESET FOR NESTED ELEMENTS
+   ========================================================================== */
+.ontario-accordions__container .ontario-h1,
+.ontario-accordions__container .ontario-h2,
+.ontario-accordions__container .ontario-h3,
+.ontario-accordions__container .ontario-h4,
+.ontario-accordions__container .ontario-h5,
+.ontario-accordions__container p,
+.ontario-accordions__container h1,
+.ontario-accordions__container h2,
+.ontario-accordions__container h3,
+.ontario-accordions__container h4,
+.ontario-accordions__container h5,
+.ontario-accordions__container h6 {
+  margin: 0;
+}
+
+/* ==========================================================================
+   HIGH CONTRAST MODE SUPPORT
+   WCAG 1.4.11: Non-text Contrast
+   ========================================================================== */
+@media (prefers-contrast: high) {
+  .ontario-accordion {
+    border-color: CanvasText;
+  }
+
+  .ontario-accordion__button {
+    color: LinkText;
+    background-color: Canvas;
+  }
+
+  .ontario-accordion__button:hover,
+  .ontario-accordion__button:focus {
+    background-color: Canvas;
+    color: LinkText;
+  }
+
+  .ontario-accordion__button:focus {
+    outline: 3px solid Highlight;
+    outline-offset: -3px;
+    box-shadow: none;
+  }
+
+  .ontario-accordion__button--expand-all {
+    color: LinkText;
+  }
+
+  .ontario-accordion__button--expand-all:focus {
+    outline: 3px solid Highlight;
+    outline-offset: 2px;
+    box-shadow: none;
+  }
+
+  .ontario-accordion__content {
+    background-color: Canvas;
+    color: CanvasText;
+  }
+
+  .ontario-accordion__button .ontario-icon {
+    fill: LinkText;
+  }
+}
+
+/* Forced colors mode (Windows High Contrast) */
+@media (forced-colors: active) {
+  .ontario-accordion {
+    border-color: ButtonText;
+    forced-color-adjust: none;
+  }
+
+  .ontario-accordion__button {
+    color: LinkText;
+    forced-color-adjust: none;
+  }
+
+  .ontario-accordion__button:focus {
+    outline: 3px solid Highlight;
+    outline-offset: -3px;
+  }
+
+  .ontario-accordion__button--expand-all:focus {
+    outline: 3px solid Highlight;
+    outline-offset: 2px;
+  }
+
+  .ontario-accordion__button .ontario-icon {
+    fill: LinkText;
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnAccordionOmni/sfGpsDsCaOnAccordionOmni.html
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnAccordionOmni/sfGpsDsCaOnAccordionOmni.html
@@ -1,0 +1,123 @@
+<template>
+  <div class={computedContainerClassName}>
+    <!-- Single Accordion Mode (when title is provided without items) -->
+    <template lwc:if={hasSingleItem}>
+      <div class={computedSingleClassName}>
+        <h3 class={computedSingleHeadingClassName}>
+          <button
+            class="ontario-accordion__button"
+            id={singleButtonId}
+            aria-expanded={computedAriaExpanded}
+            aria-controls={singleContentId}
+            data-toggle="ontario-collapse"
+            onclick={handleSingleToggle}
+          >
+            <span class="ontario-accordion__button-icon--close">
+              <svg
+                class="ontario-icon"
+                aria-hidden="true"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" />
+              </svg>
+            </span>
+            <span class="ontario-accordion__button-icon--open">
+              <svg
+                class="ontario-icon"
+                aria-hidden="true"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6z" />
+              </svg>
+            </span>
+            <span class="ontario-accordion__button-text">{title}</span>
+          </button>
+        </h3>
+        <section
+          id={singleContentId}
+          class={computedSingleContentClassName}
+          aria-labelledby={singleButtonId}
+          aria-hidden={computedAriaHidden}
+          data-toggle="ontario-expander-content"
+        >
+          <slot></slot>
+        </section>
+      </div>
+    </template>
+
+    <!-- Multiple Accordion Items Mode (when itemsJson is provided) -->
+    <template lwc:if={hasItems}>
+      <!-- Expand/Collapse All Controls -->
+      <div class="ontario-accordion__controls">
+        <button
+          lwc:if={showExpandAll}
+          class="ontario-accordion__button--expand-all"
+          onclick={handleExpandAll}
+        >
+          <span class="ontario-accordion--expand-open-all">+ Expand all</span>
+        </button>
+        <button
+          lwc:if={showCollapseAll}
+          class="ontario-accordion__button--expand-all"
+          onclick={handleCollapseAll}
+        >
+          <span class="ontario-accordion--expand-close-all"
+            >- Collapse all</span
+          >
+        </button>
+      </div>
+
+      <!-- Accordion Items -->
+      <template for:each={decoratedItems} for:item="item">
+        <div key={item._id} class={item.computedClassName}>
+          <h3 class={item.computedHeadingClassName}>
+            <button
+              class="ontario-accordion__button"
+              id={item._buttonId}
+              aria-expanded={item.computedAriaExpanded}
+              aria-controls={item._contentId}
+              data-toggle="ontario-collapse"
+              data-index={item._index}
+              onclick={handleItemToggle}
+            >
+              <span class="ontario-accordion__button-icon--close">
+                <svg
+                  class="ontario-icon"
+                  aria-hidden="true"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" />
+                </svg>
+              </span>
+              <span class="ontario-accordion__button-icon--open">
+                <svg
+                  class="ontario-icon"
+                  aria-hidden="true"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6z" />
+                </svg>
+              </span>
+              <span class="ontario-accordion__button-text">{item.title}</span>
+            </button>
+          </h3>
+          <section
+            id={item._contentId}
+            class={item.computedContentClassName}
+            aria-labelledby={item._buttonId}
+            aria-hidden={item.computedAriaHidden}
+            data-toggle="ontario-expander-content"
+          >
+            <lightning-formatted-rich-text
+              value={item.content}
+            ></lightning-formatted-rich-text>
+          </section>
+        </div>
+      </template>
+    </template>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnAccordionOmni/sfGpsDsCaOnAccordionOmni.js
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnAccordionOmni/sfGpsDsCaOnAccordionOmni.js
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { LightningElement, api, track } from "lwc";
+
+const DEBUG = false;
+const CLASS_NAME = "SfGpsDsCaOnAccordionOmni";
+
+/**
+ * Ontario Design System Accordion for OmniStudio Custom LWC
+ * Shadow DOM version for OmniStudio compatibility
+ *
+ * Usage in OmniScript:
+ * - LWC Component Name: sfGpsDsCaOnAccordionOmni
+ * - Custom Attributes:
+ *   - title: Main accordion title (for single accordion mode)
+ *   - isOpen: Whether accordion starts open (default false)
+ *   - itemsJson: JSON array of {title, content} objects for multiple accordion items
+ */
+export default class SfGpsDsCaOnAccordionOmni extends LightningElement {
+  /* ========================================
+   * PUBLIC @api PROPERTIES
+   * ======================================== */
+
+  @api title = "";
+  @api className = "";
+
+  /* ========================================
+   * PRIVATE STATE
+   * ======================================== */
+
+  @track _items = [];
+  @track _openIndexes = new Set();
+  @track _isOpen = false;
+
+  /* ========================================
+   * PUBLIC API - isOpen with getter/setter
+   * ======================================== */
+
+  @api
+  get isOpen() {
+    return this._isOpen;
+  }
+  set isOpen(value) {
+    this._isOpen = value;
+  }
+
+  _accordionId = `accordion-${Math.random().toString(36).substring(2, 11)}`;
+
+  /* ========================================
+   * PUBLIC API
+   * ======================================== */
+
+  @api
+  get itemsJson() {
+    return JSON.stringify(this._items);
+  }
+  set itemsJson(val) {
+    try {
+      if (typeof val === "string" && val.trim()) {
+        this._items = JSON.parse(val);
+      } else if (Array.isArray(val)) {
+        this._items = val;
+      } else {
+        this._items = [];
+      }
+      // Initialize open state for each item
+      this._items = this._items.map((item, index) => ({
+        ...item,
+        _index: index,
+        _id: `${this._accordionId}-item-${index}`,
+        _buttonId: `${this._accordionId}-button-${index}`,
+        _contentId: `${this._accordionId}-content-${index}`,
+        _isOpen: item.isOpen || false
+      }));
+    } catch (e) {
+      if (DEBUG) console.error(CLASS_NAME, "Error parsing itemsJson:", e);
+      this._items = [];
+    }
+  }
+
+  @api
+  expandAll() {
+    this._items = this._items.map((item) => ({ ...item, _isOpen: true }));
+  }
+
+  @api
+  collapseAll() {
+    this._items = this._items.map((item) => ({ ...item, _isOpen: false }));
+  }
+
+  @api
+  toggleItem(index) {
+    if (index >= 0 && index < this._items.length) {
+      this._items = this._items.map((item, i) => {
+        return i === index ? { ...item, _isOpen: !item._isOpen } : item;
+      });
+    }
+  }
+
+  /* ========================================
+   * LIFECYCLE
+   * ======================================== */
+
+  connectedCallback() {
+    if (DEBUG) console.log(CLASS_NAME, "connectedCallback");
+  }
+
+  /* ========================================
+   * COMPUTED PROPERTIES
+   * ======================================== */
+
+  get hasItems() {
+    return this._items && this._items.length > 0;
+  }
+
+  get hasSingleItem() {
+    return !!this.title && !this.hasItems;
+  }
+
+  get computedContainerClassName() {
+    return `ontario-accordions__container ${this.className || ""}`.trim();
+  }
+
+  get computedSingleClassName() {
+    return `ontario-accordion ${this.isOpen ? "open" : ""}`.trim();
+  }
+
+  get computedSingleHeadingClassName() {
+    return `ontario-accordion__heading ${this.isOpen ? "ontario-expander--active" : ""}`;
+  }
+
+  get computedSingleContentClassName() {
+    return `ontario-accordion__content ${this.isOpen ? "ontario-accordion__content--opened" : "ontario-accordion__content--closed"}`;
+  }
+
+  get computedAriaExpanded() {
+    return this.isOpen ? "true" : "false";
+  }
+
+  get computedAriaHidden() {
+    return this.isOpen ? "false" : "true";
+  }
+
+  get singleButtonId() {
+    return `${this._accordionId}-button`;
+  }
+
+  get singleContentId() {
+    return `${this._accordionId}-content`;
+  }
+
+  get decoratedItems() {
+    return this._items.map((item) => ({
+      ...item,
+      computedClassName:
+        `ontario-accordion ${item._isOpen ? "open" : ""}`.trim(),
+      computedHeadingClassName: `ontario-accordion__heading ${item._isOpen ? "ontario-expander--active" : ""}`,
+      computedContentClassName: `ontario-accordion__content ${item._isOpen ? "ontario-accordion__content--opened" : "ontario-accordion__content--closed"}`,
+      computedAriaExpanded: item._isOpen ? "true" : "false",
+      computedAriaHidden: item._isOpen ? "false" : "true"
+    }));
+  }
+
+  /* ========================================
+   * EVENT HANDLERS
+   * ======================================== */
+
+  handleSingleToggle() {
+    this._isOpen = !this._isOpen;
+
+    this.dispatchEvent(
+      new CustomEvent("toggle", {
+        detail: {
+          isOpen: this._isOpen,
+          title: this.title
+        },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    if (DEBUG)
+      console.log(CLASS_NAME, "Single accordion toggled:", this._isOpen);
+  }
+
+  handleItemToggle(event) {
+    const index = parseInt(event.currentTarget.dataset.index, 10);
+
+    if (index >= 0 && index < this._items.length) {
+      this._items = this._items.map((item, i) => {
+        return i === index ? { ...item, _isOpen: !item._isOpen } : item;
+      });
+
+      const toggledItem = this._items[index];
+
+      this.dispatchEvent(
+        new CustomEvent("toggle", {
+          detail: {
+            index,
+            isOpen: toggledItem._isOpen,
+            title: toggledItem.title
+          },
+          bubbles: true,
+          composed: true
+        })
+      );
+
+      if (DEBUG)
+        console.log(CLASS_NAME, "Item toggled:", index, toggledItem._isOpen);
+    }
+  }
+
+  handleExpandAll() {
+    this.expandAll();
+
+    this.dispatchEvent(
+      new CustomEvent("expandall", {
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  handleCollapseAll() {
+    this.collapseAll();
+
+    this.dispatchEvent(
+      new CustomEvent("collapseall", {
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  /* ========================================
+   * PRIVATE METHODS
+   * ======================================== */
+
+  get allExpanded() {
+    return this._items.length > 0 && this._items.every((item) => item._isOpen);
+  }
+
+  get showExpandAll() {
+    return !this.allExpanded;
+  }
+
+  get showCollapseAll() {
+    return this.allExpanded;
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnAccordionOmni/sfGpsDsCaOnAccordionOmni.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnAccordionOmni/sfGpsDsCaOnAccordionOmni.js-meta.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>true</isExposed>
+  <masterLabel>Ontario DS Accordion (OmniStudio)</masterLabel>
+  <description
+  >Ontario Design System Accordion component for OmniStudio Custom LWC elements. Shadow DOM compatible with expand/collapse functionality.</description>
+  <targets>
+    <target>lightningCommunity__Page</target>
+    <target>lightningCommunity__Default</target>
+  </targets>
+  <targetConfigs>
+    <targetConfig targets="lightningCommunity__Default">
+      <property
+        name="title"
+        type="String"
+        label="Title"
+        description="Accordion title (for single accordion mode)"
+      />
+      <property
+        name="isOpen"
+        type="Boolean"
+        label="Start Open"
+        description="Whether the accordion starts in open state"
+        default="false"
+      />
+      <property
+        name="itemsJson"
+        type="String"
+        label="Items JSON"
+        description="JSON array of accordion items: [{title, content, isOpen}]"
+      />
+      <property
+        name="className"
+        type="String"
+        label="CSS Class"
+        description="Additional CSS classes"
+      />
+    </targetConfig>
+  </targetConfigs>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCalloutOmni/sfGpsDsCaOnCalloutOmni.css
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCalloutOmni/sfGpsDsCaOnCalloutOmni.css
@@ -1,0 +1,216 @@
+/*
+ * Ontario Design System - Callout (OmniStudio)
+ * Shadow DOM compatible styles
+ */
+
+/* ========================================
+ * BASE CALLOUT STYLES
+ * ======================================== */
+
+.ontario-callout {
+  border-left: 0.25rem solid #367a76;
+  padding: 1.5rem;
+  margin: 2rem 0 2.5rem 0;
+  background-color: #f2f2f2;
+  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.ontario-callout * {
+  max-width: 48rem;
+}
+
+.ontario-callout *:last-child {
+  margin-bottom: 0;
+}
+
+/* ========================================
+ * TYPED CALLOUT STYLES
+ * Alert-style callouts with background colors and icons
+ * ======================================== */
+
+.ontario-callout--typed {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  padding: 1.25rem 1.5rem;
+}
+
+.ontario-callout--typed .ontario-callout__icon {
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-top: 0.125rem;
+}
+
+.ontario-callout--typed .ontario-callout__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.ontario-callout__title {
+  margin: 0 0 0.5rem 0;
+  font-weight: 700;
+  font-size: 1.125rem;
+  line-height: 1.56;
+  font-family:
+    "Raleway", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+@media screen and (min-width: 40em) {
+  .ontario-callout__title {
+    font-size: 1.1875rem;
+    line-height: 1.5;
+  }
+}
+
+.ontario-callout--typed p {
+  margin: 0 0 1rem 0;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.ontario-callout--typed p:last-child {
+  margin-bottom: 0;
+}
+
+/* ========================================
+ * INFORMATION CALLOUT (Blue)
+ * ======================================== */
+
+.ontario-callout--information {
+  background-color: var(--ontario-colour-info-light, #e8f4fd);
+  border-left: 0.25rem solid var(--ontario-colour-information, #1080a6);
+}
+
+.ontario-callout--information .ontario-callout__icon {
+  fill: var(--ontario-colour-information, #1080a6);
+}
+
+.ontario-callout--information .ontario-callout__title {
+  color: var(--ontario-colour-black, #1a1a1a);
+}
+
+/* ========================================
+ * WARNING CALLOUT (Yellow/Gold)
+ * ======================================== */
+
+.ontario-callout--warning {
+  background-color: var(--ontario-colour-warning-light, #fef6e6);
+  border-left: 0.25rem solid var(--ontario-colour-warning-dark, #8a600d);
+}
+
+.ontario-callout--warning .ontario-callout__icon {
+  fill: var(--ontario-colour-warning-dark, #8a600d);
+}
+
+.ontario-callout--warning .ontario-callout__title {
+  color: var(--ontario-colour-black, #1a1a1a);
+}
+
+/* ========================================
+ * ERROR CALLOUT (Red)
+ * ======================================== */
+
+.ontario-callout--error {
+  background-color: var(--ontario-colour-error-light, #fce4e4);
+  border-left: 0.25rem solid var(--ontario-colour-error, #cd0000);
+}
+
+.ontario-callout--error .ontario-callout__icon {
+  fill: var(--ontario-colour-error, #cd0000);
+}
+
+.ontario-callout--error .ontario-callout__title {
+  color: var(--ontario-colour-error, #cd0000);
+}
+
+/* ========================================
+ * SUCCESS CALLOUT (Green)
+ * ======================================== */
+
+.ontario-callout--success {
+  background-color: var(--ontario-colour-success-light, #e6f4ea);
+  border-left: 0.25rem solid var(--ontario-colour-success, #118847);
+}
+
+.ontario-callout--success .ontario-callout__icon {
+  fill: var(--ontario-colour-success, #118847);
+}
+
+.ontario-callout--success .ontario-callout__title {
+  color: var(--ontario-colour-black, #1a1a1a);
+}
+
+/* ========================================
+ * NO-HEADING MODIFIER
+ * ======================================== */
+
+.ontario-callout--typed.ontario-callout--no-heading .ontario-callout__icon {
+  margin-top: 0;
+}
+
+/* ========================================
+ * HIGH CONTRAST MODE SUPPORT
+ * WCAG 1.4.11: Non-text Contrast
+ * ======================================== */
+
+@media (prefers-contrast: high) {
+  .ontario-callout--information,
+  .ontario-callout--warning,
+  .ontario-callout--error,
+  .ontario-callout--success {
+    border-width: 0.375rem;
+  }
+
+  .ontario-callout--warning {
+    background-color: #fff3cd;
+  }
+
+  .ontario-callout--error {
+    background-color: #f8d7da;
+  }
+
+  .ontario-callout__title {
+    color: CanvasText;
+  }
+
+  .ontario-callout--information .ontario-callout__icon,
+  .ontario-callout--warning .ontario-callout__icon,
+  .ontario-callout--error .ontario-callout__icon,
+  .ontario-callout--success .ontario-callout__icon {
+    fill: CanvasText;
+  }
+}
+
+/* Forced colors mode (Windows High Contrast) */
+@media (forced-colors: active) {
+  .ontario-callout {
+    border-color: CanvasText;
+    background-color: Canvas;
+    forced-color-adjust: none;
+  }
+
+  .ontario-callout--information {
+    border-color: Highlight;
+  }
+
+  .ontario-callout--warning {
+    border-color: Mark;
+  }
+
+  .ontario-callout--error {
+    border-color: LinkText;
+  }
+
+  .ontario-callout--success {
+    border-color: Highlight;
+  }
+
+  .ontario-callout__title {
+    color: CanvasText;
+  }
+
+  .ontario-callout__icon {
+    fill: CanvasText;
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCalloutOmni/sfGpsDsCaOnCalloutOmni.html
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCalloutOmni/sfGpsDsCaOnCalloutOmni.html
@@ -1,0 +1,71 @@
+<template>
+  <section class={computedClassName} role="note" aria-live="polite">
+    <!-- Information Icon -->
+    <svg
+      lwc:if={isInfo}
+      class="ontario-callout__icon"
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+      />
+    </svg>
+
+    <!-- Warning Icon -->
+    <svg
+      lwc:if={isWarning}
+      class="ontario-callout__icon"
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+    </svg>
+
+    <!-- Error Icon -->
+    <svg
+      lwc:if={isError}
+      class="ontario-callout__icon"
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+      />
+    </svg>
+
+    <!-- Success Icon -->
+    <svg
+      lwc:if={isSuccess}
+      class="ontario-callout__icon"
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+      />
+    </svg>
+
+    <!-- Content wrapper -->
+    <div class="ontario-callout__content">
+      <!-- Title -->
+      <h2 lwc:if={hasTitle} class="ontario-callout__title ontario-h5">
+        {title}
+      </h2>
+
+      <!-- Content -->
+      <p lwc:if={hasContent}>{content}</p>
+
+      <!-- Slot for additional content -->
+      <slot></slot>
+    </div>
+  </section>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCalloutOmni/sfGpsDsCaOnCalloutOmni.js
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCalloutOmni/sfGpsDsCaOnCalloutOmni.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { LightningElement, api } from "lwc";
+
+const DEBUG = false;
+const CLASS_NAME = "SfGpsDsCaOnCalloutOmni";
+
+/**
+ * Valid variant values with their CSS class mappings
+ */
+const VARIANT_VALUES = {
+  info: "ontario-callout--information",
+  information: "ontario-callout--information",
+  warning: "ontario-callout--warning",
+  error: "ontario-callout--error",
+  success: "ontario-callout--success"
+};
+
+const VARIANT_DEFAULT = "info";
+
+/**
+ * Ontario Design System Callout for OmniStudio Custom LWC
+ * Shadow DOM version for OmniStudio compatibility
+ *
+ * Usage in OmniScript:
+ * - LWC Component Name: sfGpsDsCaOnCalloutOmni
+ * - Custom Attributes:
+ *   - title: Callout heading text
+ *   - content: Callout body content
+ *   - variant: info (default), warning, error, success
+ */
+export default class SfGpsDsCaOnCalloutOmni extends LightningElement {
+  /* ========================================
+   * PUBLIC @api PROPERTIES
+   * ======================================== */
+
+  /**
+   * Callout title/heading text
+   */
+  @api title = "";
+
+  /**
+   * Callout body content
+   */
+  @api content = "";
+
+  /**
+   * Callout variant: info (default), warning, error, success
+   */
+  @api variant = VARIANT_DEFAULT;
+
+  /* ========================================
+   * LIFECYCLE
+   * ======================================== */
+
+  connectedCallback() {
+    if (DEBUG) console.log(CLASS_NAME, "connectedCallback");
+  }
+
+  /* ========================================
+   * COMPUTED PROPERTIES
+   * ======================================== */
+
+  /**
+   * Get the normalized variant key
+   */
+  get _variantKey() {
+    const normalizedVariant = (this.variant || "").toLowerCase().trim();
+    if (VARIANT_VALUES[normalizedVariant]) {
+      return normalizedVariant;
+    }
+    return VARIANT_DEFAULT;
+  }
+
+  /**
+   * Get the CSS class for the callout container
+   */
+  get computedClassName() {
+    const variantClass =
+      VARIANT_VALUES[this._variantKey] || VARIANT_VALUES[VARIANT_DEFAULT];
+    let classes = `ontario-callout ontario-callout--typed ${variantClass}`;
+
+    // Add no-heading modifier if no title
+    if (!this.title) {
+      classes += " ontario-callout--no-heading";
+    }
+
+    return classes;
+  }
+
+  /**
+   * Returns true if this is an info/information callout
+   */
+  get isInfo() {
+    return this._variantKey === "info" || this._variantKey === "information";
+  }
+
+  /**
+   * Returns true if this is a warning callout
+   */
+  get isWarning() {
+    return this._variantKey === "warning";
+  }
+
+  /**
+   * Returns true if this is an error callout
+   */
+  get isError() {
+    return this._variantKey === "error";
+  }
+
+  /**
+   * Returns true if this is a success callout
+   */
+  get isSuccess() {
+    return this._variantKey === "success";
+  }
+
+  /**
+   * Returns true if title has content
+   */
+  get hasTitle() {
+    return !!this.title;
+  }
+
+  /**
+   * Returns true if content has content
+   */
+  get hasContent() {
+    return !!this.content;
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCalloutOmni/sfGpsDsCaOnCalloutOmni.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCalloutOmni/sfGpsDsCaOnCalloutOmni.js-meta.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>true</isExposed>
+  <masterLabel>Ontario DS Callout (OmniStudio)</masterLabel>
+  <description
+  >Ontario Design System Callout component for OmniStudio Custom LWC elements. Shadow DOM compatible.</description>
+  <targets>
+    <target>lightningCommunity__Page</target>
+    <target>lightningCommunity__Default</target>
+  </targets>
+  <targetConfigs>
+    <targetConfig targets="lightningCommunity__Default">
+      <property
+        name="title"
+        type="String"
+        label="Title"
+        description="Callout heading text"
+      />
+      <property
+        name="content"
+        type="String"
+        label="Content"
+        description="Callout body content"
+      />
+      <property
+        name="variant"
+        type="String"
+        label="Variant"
+        description="Callout style: info (default), warning, error, success"
+        default="info"
+      />
+    </targetConfig>
+  </targetConfigs>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCardOmni/sfGpsDsCaOnCardOmni.css
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCardOmni/sfGpsDsCaOnCardOmni.css
@@ -1,0 +1,227 @@
+/*
+ * Ontario Design System - Card (OmniStudio)
+ * Shadow DOM compatible styles
+ */
+
+/* Base Card Styles */
+.ontario-card {
+  box-shadow: 0rem 0.1875rem 0.5rem 0.0625rem rgba(0, 0, 0, 0.4);
+  border-radius: 4px;
+  margin-bottom: 2.5rem;
+  padding: 0;
+  height: calc(100% - 2.5rem);
+  list-style-type: none;
+  transition: all 0.3s ease-in-out;
+  position: relative;
+  cursor: pointer;
+  background: #ffffff;
+  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.ontario-card:hover {
+  box-shadow: 0rem 0.375rem 0.75rem 0.125rem rgba(0, 0, 0, 0.35);
+}
+
+.ontario-card:focus-within {
+  box-shadow: 0 0 0 4px #009adb;
+  outline: 4px solid transparent;
+  transition: box-shadow 0.1s ease-in-out;
+}
+
+.ontario-card:active {
+  box-shadow: 0 0 0 4px #009adb;
+  background-color: #f2f2f2;
+}
+
+@media screen and (max-width: 40em) {
+  .ontario-card {
+    margin-bottom: 3rem;
+    width: 100% !important;
+    max-width: 100%;
+  }
+}
+
+/* Card with Image */
+.ontario-card--image-true {
+  margin-top: -0.5rem;
+}
+
+/* Image Container */
+.ontario-card__image-container {
+  margin-bottom: -0.5rem;
+  overflow: hidden;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+/* Card Image */
+.ontario-card__image {
+  width: 100%;
+  height: auto;
+  min-height: 180px;
+  max-height: 220px;
+  object-fit: cover;
+  background-size: 100% 100%;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  display: block;
+}
+
+/* Text Container */
+.ontario-card__text-container {
+  padding: 0;
+  width: 100%;
+}
+
+/* Card Heading/Title */
+.ontario-card__heading {
+  font-style: normal;
+  font-weight: 700;
+  text-rendering: optimizeLegibility;
+  margin-bottom: 1rem;
+  font-feature-settings: normal;
+  font-family:
+    "Raleway", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 1.25rem;
+  letter-spacing: 0.03rem;
+  line-height: 1.5;
+  margin: 0 0 0.75rem 0;
+  max-width: 48rem;
+}
+
+@media screen and (min-width: 40em) {
+  .ontario-card__heading {
+    font-size: 1.5rem;
+    letter-spacing: 0.0313rem;
+    line-height: 1.5;
+  }
+}
+
+.ontario-card__title {
+  margin: 0;
+  border-radius: 4px 4px 0 0;
+  padding: 1.25rem 1.5rem 0.5rem 1.5rem;
+  transition: text-decoration 0.3s ease-in-out;
+  background-color: #ffffff;
+  max-width: none;
+}
+
+.ontario-card--image-true .ontario-card__title {
+  border-radius: 0;
+}
+
+.ontario-card:hover .ontario-card__title {
+  text-decoration-line: underline;
+  text-decoration-color: #1a1a1a;
+}
+
+@media screen and (max-width: 73em) {
+  .ontario-card__title {
+    font-size: 1.25rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}
+
+/* Card Link */
+.ontario-card__link {
+  color: #1a1a1a;
+  text-decoration: none;
+  outline: none;
+}
+
+.ontario-card__link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.ontario-card__link:focus {
+  box-shadow: none;
+}
+
+.ontario-card__link:active {
+  outline: none;
+}
+
+/* Card Description */
+.ontario-card__description {
+  margin: 0;
+  padding: 0.5rem 1.5rem 1rem 1.5rem;
+  background-color: #ffffff;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #1a1a1a;
+}
+
+.ontario-card__description p {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+@media screen and (max-width: 73em) {
+  .ontario-card__description {
+    padding: 0.5rem 1rem 1rem 1rem;
+  }
+}
+
+/* CTA Container */
+.ontario-card__cta {
+  padding: 0.5rem 1.5rem 1.5rem 1.5rem;
+  background-color: #ffffff;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+@media screen and (max-width: 73em) {
+  .ontario-card__cta {
+    padding: 0.5rem 1rem 1.5rem 1rem;
+  }
+}
+
+/* Ontario Button Styles */
+.ontario-button {
+  border-radius: 4px;
+  box-sizing: border-box;
+  box-shadow: none;
+  display: inline-block;
+  font-size: 1.125rem;
+  font-weight: 600;
+  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  min-width: 10rem;
+  padding: 0.625rem 1.5rem;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease-in-out,
+    border-color 0.2s ease-in-out;
+  position: relative;
+  z-index: 1;
+}
+
+.ontario-button--primary {
+  background-color: #1a1a1a;
+  border: 2px solid #1a1a1a;
+  color: #ffffff;
+}
+
+.ontario-button--primary:hover {
+  background-color: #4d4d4d;
+  border-color: #4d4d4d;
+  color: #ffffff;
+}
+
+.ontario-button--primary:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 2px;
+}
+
+.ontario-button--primary:active {
+  background-color: #666666;
+  border-color: #666666;
+}

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCardOmni/sfGpsDsCaOnCardOmni.html
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCardOmni/sfGpsDsCaOnCardOmni.html
@@ -1,0 +1,35 @@
+<template>
+  <article class={computedCardClassName} onclick={handleCardClick}>
+    <!-- Card Image -->
+    <div lwc:if={hasImage} class="ontario-card__image-container">
+      <img class="ontario-card__image" src={imageUrl} alt="" loading="lazy" />
+    </div>
+
+    <!-- Card Content -->
+    <div class="ontario-card__text-container">
+      <!-- Card Title -->
+      <h3 class="ontario-card__heading ontario-card__title">
+        <template lwc:if={hasCta}>
+          <a href={ctaUrl} class="ontario-card__link">{title}</a>
+        </template>
+        <template lwc:else> {title} </template>
+      </h3>
+
+      <!-- Card Description -->
+      <div lwc:if={hasDescription} class="ontario-card__description">
+        <p>{description}</p>
+      </div>
+
+      <!-- Call-to-Action Button -->
+      <div lwc:if={hasCtaButton} class="ontario-card__cta">
+        <a
+          href={ctaUrl}
+          class="ontario-button ontario-button--primary"
+          onclick={handleCtaClick}
+        >
+          {ctaLabel}
+        </a>
+      </div>
+    </div>
+  </article>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCardOmni/sfGpsDsCaOnCardOmni.js
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCardOmni/sfGpsDsCaOnCardOmni.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { LightningElement, api } from "lwc";
+
+/**
+ * Ontario Design System Card for OmniStudio Custom LWC
+ * Shadow DOM version for OmniStudio compatibility
+ *
+ * Usage in OmniScript:
+ * - LWC Component Name: sfGpsDsCaOnCardOmni
+ * - Custom Attributes:
+ *   - title: Card title/heading
+ *   - description: Card description text
+ *   - imageUrl: URL to card image
+ *   - ctaLabel: Call-to-action button label
+ *   - ctaUrl: Call-to-action button URL
+ *   - className: Additional CSS classes
+ */
+export default class SfGpsDsCaOnCardOmni extends LightningElement {
+  /* ========================================
+   * PUBLIC @api PROPERTIES
+   * ======================================== */
+
+  @api title = "";
+  @api description = "";
+  @api imageUrl = "";
+  @api ctaLabel = "";
+  @api ctaUrl = "";
+  @api className = "";
+
+  /* ========================================
+   * COMPUTED PROPERTIES
+   * ======================================== */
+
+  get computedCardClassName() {
+    let classes = "ontario-card";
+    if (this.imageUrl) {
+      classes += " ontario-card--image-true";
+    }
+    if (this.className) {
+      classes += ` ${this.className}`;
+    }
+    return classes;
+  }
+
+  get hasImage() {
+    return !!this.imageUrl;
+  }
+
+  get hasDescription() {
+    return !!this.description;
+  }
+
+  get hasCta() {
+    return !!this.ctaLabel && !!this.ctaUrl;
+  }
+
+  get hasCtaButton() {
+    return !!this.ctaLabel;
+  }
+
+  /* ========================================
+   * EVENT HANDLERS
+   * ======================================== */
+
+  handleCtaClick(event) {
+    // Dispatch custom event for OmniScript integration
+    this.dispatchEvent(
+      new CustomEvent("ctaclick", {
+        detail: {
+          url: this.ctaUrl,
+          label: this.ctaLabel
+        },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    // If no URL, prevent default navigation
+    if (!this.ctaUrl) {
+      event.preventDefault();
+    }
+  }
+
+  handleCardClick(event) {
+    // Only handle if clicking the card itself (not button)
+    if (event.target.tagName !== "A" && event.target.tagName !== "BUTTON") {
+      this.dispatchEvent(
+        new CustomEvent("cardclick", {
+          detail: {
+            title: this.title,
+            url: this.ctaUrl
+          },
+          bubbles: true,
+          composed: true
+        })
+      );
+    }
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCardOmni/sfGpsDsCaOnCardOmni.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnCardOmni/sfGpsDsCaOnCardOmni.js-meta.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>true</isExposed>
+  <masterLabel>Ontario DS Card (OmniStudio)</masterLabel>
+  <description
+  >Ontario Design System Card component for OmniStudio Custom LWC elements. Shadow DOM compatible.</description>
+  <targets>
+    <target>lightningCommunity__Page</target>
+    <target>lightningCommunity__Default</target>
+  </targets>
+  <targetConfigs>
+    <targetConfig targets="lightningCommunity__Default">
+      <property
+        name="title"
+        type="String"
+        label="Title"
+        description="Card title/heading"
+      />
+      <property
+        name="description"
+        type="String"
+        label="Description"
+        description="Card description text"
+      />
+      <property
+        name="imageUrl"
+        type="String"
+        label="Image URL"
+        description="URL to card image"
+      />
+      <property
+        name="ctaLabel"
+        type="String"
+        label="CTA Label"
+        description="Call-to-action button label"
+      />
+      <property
+        name="ctaUrl"
+        type="String"
+        label="CTA URL"
+        description="Call-to-action button URL"
+      />
+      <property
+        name="className"
+        type="String"
+        label="CSS Class"
+        description="Additional CSS classes"
+      />
+    </targetConfig>
+  </targetConfigs>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnFormFormReviewOmni/sfGpsDsCaOnFormFormReviewOmni.css
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnFormFormReviewOmni/sfGpsDsCaOnFormFormReviewOmni.css
@@ -1,0 +1,116 @@
+/* Ontario Form Review - OmniStudio Custom LWC Styles */
+
+.sfgpsdscaon-form-review {
+  padding: 1rem 0;
+}
+
+.sfgpsdscaon-form-review__section {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #ccc;
+}
+
+.sfgpsdscaon-form-review__section:last-child {
+  border-bottom: none;
+}
+
+/* Summary list header with heading and change link */
+.sfgpsdscaon-summary-list__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid #1a1a1a;
+}
+
+.sfgpsdscaon-summary-list__header h2 {
+  margin: 0;
+}
+
+.sfgpsdscaon-summary-list__change-link {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+/* Summary list - key/value pairs */
+.sfgpsdscaon-summary-list {
+  margin: 0;
+  padding: 0;
+}
+
+.sfgpsdscaon-summary-list__row {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.sfgpsdscaon-summary-list__row:last-child {
+  border-bottom: none;
+}
+
+.sfgpsdscaon-summary-list__key {
+  flex: 0 0 33.33%;
+  font-weight: 600;
+  color: #1a1a1a;
+  margin: 0;
+  padding-right: 1rem;
+}
+
+.sfgpsdscaon-summary-list__value {
+  flex: 0 0 66.67%;
+  margin: 0;
+  color: #1a1a1a;
+}
+
+/* Mobile responsive */
+@media (max-width: 640px) {
+  .sfgpsdscaon-summary-list__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .sfgpsdscaon-summary-list__row {
+    flex-direction: column;
+  }
+
+  .sfgpsdscaon-summary-list__key,
+  .sfgpsdscaon-summary-list__value {
+    flex: 0 0 100%;
+    padding-right: 0;
+  }
+
+  .sfgpsdscaon-summary-list__key {
+    margin-bottom: 0.25rem;
+  }
+}
+
+/* Warning callout */
+.sfgpsdscaon-form-review__warning {
+  margin: 1.5rem 0;
+}
+
+/* Actions */
+.sfgpsdscaon-form-review__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #ccc;
+}
+
+/* Screen reader only utility */
+.ontario-show-for-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnFormFormReviewOmni/sfGpsDsCaOnFormFormReviewOmni.html
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnFormFormReviewOmni/sfGpsDsCaOnFormFormReviewOmni.html
@@ -1,0 +1,101 @@
+<!--
+  Ontario Design System Form Review - OmniStudio Custom LWC Version
+  
+  Renders collected OmniScript answers for user review.
+  Uses inline rendering (no Light DOM child dependencies).
+  
+  Accessibility:
+  - aria-live region for status announcements
+  - Proper heading hierarchy
+  - Keyboard accessible change links
+-->
+<template>
+  <div class="sfgpsdscaon-form-review">
+    <!-- Screen reader status announcements -->
+    <div
+      class="ontario-show-for-sr"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      {_statusMessage}
+    </div>
+
+    <!-- Page heading -->
+    <h1 class="ontario-h1">{heading}</h1>
+
+    <!-- Instructions -->
+    <p class="ontario-lead">{subheading}</p>
+
+    <!-- Sections -->
+    <template lwc:if={hasSections}>
+      <template for:each={sections} for:item="section">
+        <div key={section.id} class="sfgpsdscaon-form-review__section">
+          <!-- Section header with Change link -->
+          <div class="sfgpsdscaon-summary-list__header">
+            <h2 class="ontario-h4">{section.heading}</h2>
+            <a
+              href="#"
+              class="ontario-link sfgpsdscaon-summary-list__change-link"
+              data-step={section.stepName}
+              onclick={handleChangeClick}
+              aria-label={section.heading}
+            >
+              Change<span class="ontario-show-for-sr"> {section.heading}</span>
+            </a>
+          </div>
+
+          <!-- Summary list items -->
+          <dl class="sfgpsdscaon-summary-list ontario-summary-list">
+            <template for:each={section.items} for:item="item">
+              <div key={item.id} class="sfgpsdscaon-summary-list__row">
+                <dt class="sfgpsdscaon-summary-list__key">{item.key}</dt>
+                <dd class="sfgpsdscaon-summary-list__value">{item.value}</dd>
+              </div>
+            </template>
+          </dl>
+        </div>
+      </template>
+    </template>
+
+    <!-- No sections message -->
+    <template lwc:if={noSections}>
+      <div class="ontario-callout">
+        <p>No answers to review. Please complete the previous steps first.</p>
+      </div>
+    </template>
+
+    <!-- Submit warning -->
+    <template lwc:if={computedShowSubmitWarning}>
+      <div class="sfgpsdscaon-form-review__warning" role="alert">
+        <div class="ontario-callout ontario-callout--warning">
+          <h3 class="ontario-callout__title ontario-h5">Important</h3>
+          <p class="ontario-callout__content">{submitWarningMessage}</p>
+        </div>
+      </div>
+    </template>
+
+    <!-- Actions -->
+    <div
+      class="sfgpsdscaon-form-review__actions"
+      role="group"
+      aria-label="Form actions"
+    >
+      <button
+        type="button"
+        class="ontario-button ontario-button--primary"
+        onclick={handleSubmit}
+      >
+        {submitLabel}
+      </button>
+
+      <button
+        type="button"
+        class="ontario-button ontario-button--tertiary"
+        onclick={handleCancel}
+      >
+        {cancelLabel}
+      </button>
+    </div>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnFormFormReviewOmni/sfGpsDsCaOnFormFormReviewOmni.js
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnFormFormReviewOmni/sfGpsDsCaOnFormFormReviewOmni.js
@@ -1,0 +1,634 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { api, LightningElement, track } from "lwc";
+import { OmniscriptBaseMixin } from "omnistudio/omniscriptBaseMixin";
+
+const DEBUG = false;
+const CLASS_NAME = "SfGpsDsCaOnFormFormReviewOmni";
+
+/**
+ * Maximum recursion depth for nested object extraction
+ */
+const MAX_RECURSION_DEPTH = 5;
+
+/**
+ * Security blocklist - fields that should never be displayed
+ */
+const SECURITY_BLOCKLIST = new Set([
+  "ContextId",
+  "runMode",
+  "seed",
+  "OmniProcessId",
+  "OmniScriptId",
+  "OmniScriptInstanceId",
+  "OmniScriptVersionId",
+  "Id",
+  "RecordTypeId",
+  "OwnerId",
+  "CreatedById",
+  "LastModifiedById",
+  "apiKey",
+  "apiSecret",
+  "accessToken",
+  "refreshToken",
+  "authToken",
+  "sessionId",
+  "bearerToken",
+  "HTTP_Response",
+  "HTTP_Status",
+  "HTTP_Headers",
+  "httpResponse",
+  "rawResponse",
+  "TimeStamp",
+  "Timestamp",
+  "timestamp",
+  "createdDate",
+  "lastModifiedDate",
+  "errorMessage",
+  "stackTrace",
+  "debugInfo",
+  "ContentVersionId",
+  "ContentDocumentId",
+  "DocumentId"
+]);
+
+/**
+ * Security blocklist prefixes
+ */
+const SECURITY_BLOCKLIST_PREFIXES = [
+  "vlc",
+  "_",
+  "omni",
+  "OS",
+  "DRId",
+  "SId",
+  "sys",
+  "internal",
+  "debug",
+  "temp",
+  "tmp",
+  "http",
+  "api"
+];
+
+/**
+ * Form Review component for OmniStudio Custom LWC.
+ * Uses OmniscriptBaseMixin for OmniScript data access.
+ * Renders summary list inline (no Light DOM child dependencies).
+ *
+ * OmniScript Configuration:
+ * - Type: Custom Lightning Web Component
+ * - lwcName: sfGpsDsCaOnFormFormReviewOmni
+ * - customAttributes: heading, subheading, submitLabel, cancelLabel, etc.
+ */
+export default class SfGpsDsCaOnFormFormReviewOmni extends OmniscriptBaseMixin(
+  LightningElement
+) {
+  /* ========================================
+   * PUBLIC @api PROPERTIES
+   * ======================================== */
+
+  @api heading = "Review your answers";
+  @api subheading = "Please check your answers before submitting.";
+  @api submitLabel = "Submit";
+  @api cancelLabel = "Save for later";
+  @api showSubmitWarning; // String from customAttributes: "true" or "false"
+  @api submitWarningMessage =
+    "You cannot change your answers after submitting.";
+  @api autoGenerate; // String from customAttributes: "true" or "false", defaults to true behavior
+  @api excludeSteps = "";
+  @api excludeFields = "";
+  @api labelSchema = "";
+  @api fieldMapping = "";
+
+  /* ========================================
+   * PRIVATE STATE
+   * ======================================== */
+
+  @track _generatedSections = [];
+  @track _statusMessage = "";
+  _initialized = false;
+  _lastDataHash = "";
+  _excludeStepsSet = new Set();
+  _excludeFieldsSet = new Set();
+  _labelSchemaObj = {};
+  _fieldMappingObj = {};
+
+  /* ========================================
+   * LIFECYCLE
+   * ======================================== */
+
+  connectedCallback() {
+    if (DEBUG) console.log(CLASS_NAME, "connectedCallback");
+
+    // Parse configuration
+    this._parseConfiguration();
+
+    // Generate sections
+    this._generateSections();
+    this._initialized = true;
+  }
+
+  renderedCallback() {
+    if (this._initialized && this._parseAutoGenerate()) {
+      this._generateSections();
+    }
+  }
+
+  /* ========================================
+   * CONFIGURATION PARSING
+   * ======================================== */
+
+  _parseConfiguration() {
+    // Parse excludeSteps
+    if (this.excludeSteps && typeof this.excludeSteps === "string") {
+      this._excludeStepsSet = new Set(
+        this.excludeSteps
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      );
+    }
+
+    // Parse excludeFields
+    if (this.excludeFields && typeof this.excludeFields === "string") {
+      this._excludeFieldsSet = new Set(
+        this.excludeFields
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      );
+    }
+
+    // Parse labelSchema JSON
+    if (this.labelSchema) {
+      try {
+        this._labelSchemaObj =
+          typeof this.labelSchema === "string"
+            ? JSON.parse(this._unescapeJson(this.labelSchema))
+            : this.labelSchema;
+      } catch (e) {
+        if (DEBUG) console.error(CLASS_NAME, "labelSchema parse error", e);
+        this._labelSchemaObj = {};
+      }
+    }
+
+    // Parse fieldMapping JSON
+    if (this.fieldMapping) {
+      try {
+        this._fieldMappingObj =
+          typeof this.fieldMapping === "string"
+            ? JSON.parse(this._unescapeJson(this.fieldMapping))
+            : this.fieldMapping;
+      } catch (e) {
+        if (DEBUG) console.error(CLASS_NAME, "fieldMapping parse error", e);
+        this._fieldMappingObj = {};
+      }
+    }
+  }
+
+  /**
+   * Parse autoGenerate - defaults to true if not set
+   * OmniScript customAttributes pass strings, not booleans
+   */
+  _parseAutoGenerate() {
+    // Not set = default to true
+    if (this.autoGenerate === undefined || this.autoGenerate === null) {
+      return true;
+    }
+    // Boolean (shouldn't happen from customAttributes, but handle it)
+    if (typeof this.autoGenerate === "boolean") {
+      return this.autoGenerate;
+    }
+    // String from customAttributes - only "false" disables
+    if (typeof this.autoGenerate === "string") {
+      return this.autoGenerate.toLowerCase() !== "false";
+    }
+    return true;
+  }
+
+  /**
+   * Parse showSubmitWarning - defaults to false if not set
+   * OmniScript customAttributes pass strings, not booleans
+   */
+  _parseShowSubmitWarning() {
+    // Not set = default to false
+    if (
+      this.showSubmitWarning === undefined ||
+      this.showSubmitWarning === null
+    ) {
+      return false;
+    }
+    // Boolean
+    if (typeof this.showSubmitWarning === "boolean") {
+      return this.showSubmitWarning;
+    }
+    // String from customAttributes - only "true" enables
+    if (typeof this.showSubmitWarning === "string") {
+      return this.showSubmitWarning.toLowerCase() === "true";
+    }
+    return false;
+  }
+
+  /**
+   * Unescape double-escaped JSON from OmniStudio customAttributes
+   */
+  _unescapeJson(input) {
+    if (!input || typeof input !== "string") return input;
+
+    if (input.includes("\\[") || input.includes('\\"')) {
+      return input
+        .replace(/\\\[/g, "[")
+        .replace(/\\\]/g, "]")
+        .replace(/\\\{/g, "{")
+        .replace(/\\\}/g, "}")
+        .replace(/\\"/g, '"')
+        .replace(/\\\\/g, "\\");
+    }
+    return input;
+  }
+
+  /* ========================================
+   * SECTION GENERATION
+   * ======================================== */
+
+  _generateSections() {
+    if (!this._parseAutoGenerate() || !this.omniJsonData) {
+      this._generatedSections = [];
+      return;
+    }
+
+    // Simple change detection
+    const dataHash = this._computeHash(this.omniJsonData);
+    if (dataHash === this._lastDataHash) return;
+    this._lastDataHash = dataHash;
+
+    const sections = [];
+
+    try {
+      for (const [stepName, stepData] of Object.entries(this.omniJsonData)) {
+        // Skip excluded steps
+        if (this._excludeStepsSet.has(stepName)) continue;
+
+        // Skip internal fields
+        if (this._isInternalField(stepName)) continue;
+
+        // Skip non-objects
+        if (!stepData || typeof stepData !== "object") continue;
+
+        // Extract items from step
+        const items = this._extractItems(stepName, stepData, 0);
+
+        if (items.length > 0) {
+          sections.push({
+            id: `section-${stepName}`,
+            heading: this._formatLabel(stepName),
+            stepName: stepName,
+            items: items
+          });
+        }
+      }
+    } catch (e) {
+      if (DEBUG) console.error(CLASS_NAME, "Error generating sections", e);
+    }
+
+    this._generatedSections = sections;
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "Generated sections", this._generatedSections);
+    }
+  }
+
+  _extractItems(stepName, stepData, depth) {
+    if (depth >= MAX_RECURSION_DEPTH) return [];
+
+    const items = [];
+
+    for (const [fieldName, fieldValue] of Object.entries(stepData)) {
+      const fieldPath = `${stepName}:${fieldName}`;
+
+      // Security checks
+      if (SECURITY_BLOCKLIST.has(fieldName)) continue;
+      if (this._isBlocklistedPrefix(fieldName)) continue;
+      if (this._excludeFieldsSet.has(fieldPath)) continue;
+      if (this._excludeFieldsSet.has(fieldName)) continue;
+      if (this._isInternalField(fieldName)) continue;
+
+      // Skip null/undefined
+      if (fieldValue === null || fieldValue === undefined) continue;
+
+      // Handle arrays
+      if (Array.isArray(fieldValue)) {
+        const arrayValue = this._formatArrayValue(fieldValue, fieldPath);
+        if (arrayValue) {
+          items.push({
+            id: `item-${fieldPath}`,
+            key: this._getDisplayLabel(fieldPath, fieldName),
+            value: arrayValue,
+            fieldPath: fieldPath
+          });
+        }
+        continue;
+      }
+
+      // Handle nested objects (flatten single-level)
+      if (
+        typeof fieldValue === "object" &&
+        !this._isSpecialObject(fieldValue)
+      ) {
+        const nestedItems = this._extractItems(
+          fieldPath,
+          fieldValue,
+          depth + 1
+        );
+        items.push(...nestedItems);
+        continue;
+      }
+
+      // Format and add item
+      const displayValue = this._formatValue(fieldValue, fieldPath);
+      if (displayValue) {
+        items.push({
+          id: `item-${fieldPath}`,
+          key: this._getDisplayLabel(fieldPath, fieldName),
+          value: displayValue,
+          fieldPath: fieldPath
+        });
+      }
+    }
+
+    return items;
+  }
+
+  /* ========================================
+   * COMPUTED PROPERTIES
+   * ======================================== */
+
+  get sections() {
+    return this._generatedSections;
+  }
+
+  get hasSections() {
+    return this._generatedSections && this._generatedSections.length > 0;
+  }
+
+  get noSections() {
+    return !this.hasSections;
+  }
+
+  get computedShowSubmitWarning() {
+    return this._parseShowSubmitWarning();
+  }
+
+  /* ========================================
+   * FORMATTING HELPERS
+   * ======================================== */
+
+  _getDisplayLabel(fieldPath, fieldName) {
+    // Check fieldMapping first
+    if (this._fieldMappingObj[fieldPath]) {
+      return this._fieldMappingObj[fieldPath];
+    }
+    return this._formatLabel(fieldName);
+  }
+
+  _formatLabel(name) {
+    if (!name) return "";
+
+    // Remove common prefixes
+    let label = name.replace(/^(txt|sel|cb|rad|num|date|time|cur)_?/i, "");
+
+    // Insert spaces before capitals
+    label = label.replace(/([a-z])([A-Z])/g, "$1 $2");
+
+    // Replace underscores
+    label = label.replace(/_/g, " ");
+
+    // Capitalize words
+    return label
+      .split(" ")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join(" ");
+  }
+
+  _formatValue(value, fieldPath) {
+    if (value === null || value === undefined) return "";
+
+    // Boolean
+    if (typeof value === "boolean") {
+      return value ? "Yes" : "No";
+    }
+
+    // Object with label (selection)
+    if (typeof value === "object" && value.label) {
+      return value.label;
+    }
+
+    // File upload
+    if (typeof value === "object" && value.name && value.size !== undefined) {
+      const sizeKB = Math.round(value.size / 1024);
+      return `${value.name} (${sizeKB} KB)`;
+    }
+
+    // String - check labelSchema
+    if (typeof value === "string") {
+      const schemaLabel = this._lookupLabel(fieldPath, value);
+      if (schemaLabel) return schemaLabel;
+
+      // Date formatting
+      if (/^\d{4}-\d{2}-\d{2}/.test(value)) {
+        try {
+          const date = new Date(value);
+          if (!isNaN(date.getTime())) {
+            return date.toLocaleDateString("en-CA", {
+              year: "numeric",
+              month: "long",
+              day: "numeric"
+            });
+          }
+        } catch {
+          // Return raw value
+        }
+      }
+
+      return value;
+    }
+
+    // Number
+    if (typeof value === "number") {
+      return value.toLocaleString("en-CA");
+    }
+
+    return String(value);
+  }
+
+  _formatArrayValue(value, fieldPath) {
+    return value
+      .filter((v) => v !== null && v !== undefined)
+      .map((v, idx) => this._formatValue(v, `${fieldPath}[${idx}]`))
+      .filter(Boolean)
+      .join(", ");
+  }
+
+  _lookupLabel(fieldPath, rawValue) {
+    const fieldLabels = this._labelSchemaObj[fieldPath];
+    if (fieldLabels && fieldLabels[rawValue]) {
+      return fieldLabels[rawValue];
+    }
+    return null;
+  }
+
+  /* ========================================
+   * VALIDATION HELPERS
+   * ======================================== */
+
+  _isInternalField(fieldName) {
+    if (SECURITY_BLOCKLIST.has(fieldName)) return true;
+    return this._isBlocklistedPrefix(fieldName);
+  }
+
+  _isBlocklistedPrefix(fieldName) {
+    const lowerName = fieldName.toLowerCase();
+    for (const prefix of SECURITY_BLOCKLIST_PREFIXES) {
+      if (lowerName.startsWith(prefix.toLowerCase())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  _isSpecialObject(obj) {
+    if (obj.name && obj.size !== undefined) return true;
+    if (obj.ContentVersionId || obj.ContentDocumentId) return true;
+    if (obj.label !== undefined && obj.value !== undefined) return true;
+    if (obj instanceof Date) return true;
+    return false;
+  }
+
+  _computeHash(data) {
+    if (!data) return "";
+    try {
+      const keys = Object.keys(data);
+      if (keys.length === 0) return "empty";
+
+      let fieldCount = 0;
+      for (const key of keys) {
+        const stepData = data[key];
+        if (
+          stepData &&
+          typeof stepData === "object" &&
+          !Array.isArray(stepData)
+        ) {
+          fieldCount += Object.keys(stepData).length;
+        }
+      }
+      return `${keys.length}:${keys[0] || ""}:${fieldCount}`;
+    } catch {
+      return `fallback:${Date.now()}`;
+    }
+  }
+
+  /* ========================================
+   * EVENT HANDLERS
+   * ======================================== */
+
+  handleSubmit(event) {
+    event.preventDefault();
+    this._announceStatus("Submitting...");
+
+    if (typeof this.dispatchOmniEventUtil === "function") {
+      this.dispatchOmniEventUtil(this, {}, "omnisave");
+    } else {
+      this.dispatchEvent(
+        new CustomEvent("omnisave", { bubbles: true, composed: true })
+      );
+    }
+  }
+
+  handleCancel(event) {
+    event.preventDefault();
+    this._announceStatus("Saving for later...");
+
+    if (typeof this.dispatchOmniEventUtil === "function") {
+      this.dispatchOmniEventUtil(this, { saveForLater: true }, "omnisave");
+    } else {
+      this.dispatchEvent(
+        new CustomEvent("cancel", { bubbles: true, composed: true })
+      );
+    }
+  }
+
+  handleChangeClick(event) {
+    const stepName = event.currentTarget.dataset.step;
+    if (!stepName) return;
+
+    event.preventDefault();
+    this._navigateToStep(stepName);
+  }
+
+  /**
+   * Navigate to a step by name.
+   * Uses omniNavigateTo (preferred for Custom LWC) or falls back to dispatchOmniEventUtil.
+   * @param {string} stepName - Step name to navigate to
+   */
+  _navigateToStep(stepName) {
+    this._announceStatus(`Navigating to ${this._formatLabel(stepName)}...`);
+
+    // Primary: Use omniNavigateTo (works best for Custom LWC)
+    if (typeof this.omniNavigateTo === "function") {
+      this.omniNavigateTo(stepName);
+      return;
+    }
+
+    // Fallback: Try dispatchOmniEventUtil with step name
+    if (typeof this.dispatchOmniEventUtil === "function") {
+      this.dispatchOmniEventUtil(
+        this,
+        { moveToStep: stepName },
+        "omniautoadvance"
+      );
+      return;
+    }
+
+    // Last resort: Custom event
+    this.dispatchEvent(
+      new CustomEvent("omniautoadvance", {
+        bubbles: true,
+        composed: true,
+        detail: { moveToStep: stepName }
+      })
+    );
+  }
+
+  _announceStatus(message) {
+    this._statusMessage = "";
+    // eslint-disable-next-line @lwc/lwc/no-async-operation
+    setTimeout(() => {
+      this._statusMessage = message;
+    }, 100);
+  }
+
+  /* ========================================
+   * VALIDATION API
+   * ======================================== */
+
+  @api
+  checkValidity() {
+    return true;
+  }
+
+  @api
+  reportValidity() {
+    return true;
+  }
+
+  @api
+  setCustomValidity() {
+    // No-op - display only component
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnFormFormReviewOmni/sfGpsDsCaOnFormFormReviewOmni.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnFormFormReviewOmni/sfGpsDsCaOnFormFormReviewOmni.js-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>62.0</apiVersion>
+  <isExposed>true</isExposed>
+  <masterLabel>Ontario Form Review (OmniStudio Custom LWC)</masterLabel>
+  <description
+  >OmniStudio Form Review component for Custom LWC elements. Displays collected answers for user review before submission. Auto-generates Summary List sections from OmniScript data.</description>
+  <targets>
+    <target>lightningCommunity__Page</target>
+    <target>lightningCommunity__Default</target>
+    <target>lightning__RecordPage</target>
+    <target>lightning__AppPage</target>
+  </targets>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnFormUtils/sfGpsDsCaOnFormUtils.js
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnFormUtils/sfGpsDsCaOnFormUtils.js
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Shared utility functions for Ontario DS Form components.
+ * Used by both Comm (Light DOM) and Omni (Shadow DOM) versions.
+ *
+ * This reduces code duplication across component variants by ~80%.
+ */
+
+const DEBUG = false;
+const CLASS_NAME = "SfGpsDsCaOnFormUtils";
+
+/* ========================================
+ * JSON PARSING
+ * ======================================== */
+
+/**
+ * Parse JSON input that may be escaped by OmniStudio.
+ * Handles: arrays, objects, strings, and double-escaped JSON.
+ * @param {string|Array|Object} input - The input to parse
+ * @returns {Array} Parsed options array
+ */
+export function parseOptionsJson(input) {
+  if (!input) {
+    if (DEBUG) console.log(CLASS_NAME, "parseOptionsJson: input is empty");
+    return [];
+  }
+
+  // Already an array - return directly
+  if (Array.isArray(input)) {
+    if (DEBUG)
+      console.log(
+        CLASS_NAME,
+        "parseOptionsJson: input is already an array",
+        input.length
+      );
+    return input;
+  }
+
+  // Object (but not array) - wrap in array or return empty
+  if (typeof input === "object") {
+    if (DEBUG)
+      console.log(CLASS_NAME, "parseOptionsJson: input is an object", input);
+    return input.value !== undefined ? [input] : [];
+  }
+
+  // String - try to parse, handling OmniStudio double-escaping
+  if (typeof input === "string") {
+    let jsonStr = input;
+
+    // OmniStudio sometimes double-escapes JSON strings
+    if (
+      jsonStr.includes("\\[") ||
+      jsonStr.includes("\\{") ||
+      jsonStr.includes('\\"')
+    ) {
+      if (DEBUG)
+        console.log(
+          CLASS_NAME,
+          "parseOptionsJson: detected escaped JSON, unescaping"
+        );
+      jsonStr = jsonStr
+        .replace(/\\\[/g, "[")
+        .replace(/\\\]/g, "]")
+        .replace(/\\\{/g, "{")
+        .replace(/\\\}/g, "}")
+        .replace(/\\"/g, '"')
+        .replace(/\\\\/g, "\\");
+    }
+
+    try {
+      const parsed = JSON.parse(jsonStr);
+      if (DEBUG)
+        console.log(
+          CLASS_NAME,
+          "parseOptionsJson: parsed string",
+          Array.isArray(parsed) ? parsed.length : "not array"
+        );
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (e) {
+      if (DEBUG)
+        console.error(
+          CLASS_NAME,
+          "parseOptionsJson: JSON.parse failed",
+          e.message
+        );
+      return [];
+    }
+  }
+
+  if (DEBUG)
+    console.log(
+      CLASS_NAME,
+      "parseOptionsJson: unknown input type",
+      typeof input
+    );
+  return [];
+}
+
+/* ========================================
+ * ID GENERATION
+ * ======================================== */
+
+/**
+ * Generate unique IDs for accessibility attributes.
+ * @param {string} prefix - Prefix for the ID
+ * @returns {string} Unique ID
+ */
+export function generateId(prefix = "id") {
+  return `${prefix}-${Math.random().toString(36).substring(2, 11)}`;
+}
+
+/* ========================================
+ * CSS CLASS COMPUTATION
+ * ======================================== */
+
+/**
+ * Compute CSS class for dropdown/select element.
+ * @param {boolean} isInvalid - Whether the field is invalid
+ * @param {string} errorMessage - Error message (if any)
+ * @param {string} className - Additional class names
+ * @returns {string} Computed CSS class string
+ */
+export function computeSelectClassName(isInvalid, errorMessage, className) {
+  let classes = "ontario-input ontario-dropdown";
+  if (isInvalid || errorMessage) {
+    classes += " ontario-input__error";
+  }
+  if (className) {
+    classes += ` ${className}`;
+  }
+  return classes;
+}
+
+/**
+ * Compute CSS class for text input element.
+ * @param {boolean} isInvalid - Whether the field is invalid
+ * @param {string} errorMessage - Error message (if any)
+ * @param {string} className - Additional class names
+ * @returns {string} Computed CSS class string
+ */
+export function computeInputClassName(isInvalid, errorMessage, className) {
+  let classes = "ontario-input";
+  if (isInvalid || errorMessage) {
+    classes += " ontario-input__error";
+  }
+  if (className) {
+    classes += ` ${className}`;
+  }
+  return classes;
+}
+
+/**
+ * Compute CSS class for textarea element.
+ * @param {boolean} isInvalid - Whether the field is invalid
+ * @param {string} errorMessage - Error message (if any)
+ * @param {string} className - Additional class names
+ * @returns {string} Computed CSS class string
+ */
+export function computeTextareaClassName(isInvalid, errorMessage, className) {
+  let classes = "ontario-textarea";
+  if (isInvalid || errorMessage) {
+    classes += " ontario-textarea__error";
+  }
+  if (className) {
+    classes += ` ${className}`;
+  }
+  return classes;
+}
+
+/* ========================================
+ * ACCESSIBILITY
+ * ======================================== */
+
+/**
+ * Compute aria-describedby attribute.
+ * @param {string} hintText - Hint text
+ * @param {string} errorMessage - Error message
+ * @param {string} hintId - Hint element ID
+ * @param {string} errorId - Error element ID
+ * @returns {string|null} Aria-describedby value or null
+ */
+export function computeAriaDescribedBy(
+  hintText,
+  errorMessage,
+  hintId,
+  errorId
+) {
+  const ids = [];
+  if (hintText) ids.push(hintId);
+  if (errorMessage) ids.push(errorId);
+  return ids.length > 0 ? ids.join(" ") : null;
+}
+
+/**
+ * Get flag text for required/optional labels.
+ * @param {boolean} required - Is field required
+ * @param {boolean} optional - Is field optional
+ * @param {Object} labels - Labels object with Common.Required and Common.Optional
+ * @returns {string} Flag text
+ */
+export function getFlagText(required, optional, labels = null) {
+  if (required) return labels?.Common?.Required || "required";
+  if (optional) return labels?.Common?.Optional || "optional";
+  return "";
+}
+
+/* ========================================
+ * OPTIONS HANDLING
+ * ======================================== */
+
+/**
+ * Decorate options with selected state for dropdowns/radios.
+ * @param {Array} options - Options array
+ * @param {string} selectedValue - Currently selected value
+ * @returns {Array} Options with selected boolean
+ */
+export function decorateOptions(options, selectedValue) {
+  return options.map((opt) => ({
+    ...opt,
+    selected: opt.value === selectedValue
+  }));
+}
+
+/**
+ * Decorate options with checked state for checkboxes.
+ * @param {Array} options - Options array
+ * @param {Array} selectedValues - Array of selected values
+ * @returns {Array} Options with checked boolean
+ */
+export function decorateCheckboxOptions(options, selectedValues = []) {
+  const valuesSet = new Set(selectedValues);
+  return options.map((opt) => ({
+    ...opt,
+    checked: valuesSet.has(opt.value)
+  }));
+}
+
+/**
+ * Filter cascading options by parent value.
+ * @param {Array} options - Options array with parentValue property
+ * @param {string} parentValue - Parent value to filter by
+ * @returns {Array} Filtered options
+ */
+export function filterByParentValue(options, parentValue) {
+  if (!parentValue) return [];
+  return options.filter((opt) => opt.parentValue === parentValue);
+}
+
+/* ========================================
+ * EVENT CREATION
+ * ======================================== */
+
+/**
+ * Create OmniScript update event.
+ * @param {string} fieldName - Field name for OmniScript data
+ * @param {*} value - Value to update
+ * @returns {CustomEvent|null} OmniScript update event or null if no fieldName
+ */
+export function createOmniUpdateEvent(fieldName, value) {
+  if (!fieldName) return null;
+
+  return new CustomEvent("omniupdatedata", {
+    detail: { [fieldName]: value },
+    bubbles: true,
+    composed: true
+  });
+}
+
+/**
+ * Create change event with value detail.
+ * @param {*} value - Value to include in event
+ * @returns {CustomEvent} Change event
+ */
+export function createChangeEvent(value) {
+  return new CustomEvent("change", {
+    detail: { value },
+    bubbles: true,
+    composed: true
+  });
+}
+
+/**
+ * Create blur event with value detail.
+ * @param {*} value - Value to include in event
+ * @returns {CustomEvent} Blur event
+ */
+export function createBlurEvent(value) {
+  return new CustomEvent("blur", {
+    detail: { value },
+    bubbles: true,
+    composed: true
+  });
+}
+
+/**
+ * Create focus event with value detail.
+ * @param {*} value - Value to include in event
+ * @returns {CustomEvent} Focus event
+ */
+export function createFocusEvent(value) {
+  return new CustomEvent("focus", {
+    detail: { value },
+    bubbles: true,
+    composed: true
+  });
+}
+
+/* ========================================
+ * DATE UTILITIES
+ * ======================================== */
+
+/**
+ * Parse ISO date string to parts.
+ * @param {string} isoDate - ISO date string (YYYY-MM-DD)
+ * @returns {Object} Object with year, month, day
+ */
+export function parseDateParts(isoDate) {
+  if (!isoDate) return { year: "", month: "", day: "" };
+
+  const parts = isoDate.split("-");
+  return {
+    year: parts[0] || "",
+    month: parts[1] || "",
+    day: parts[2] || ""
+  };
+}
+
+/**
+ * Format date parts to ISO string.
+ * @param {string} year - Year (4 digits)
+ * @param {string} month - Month (1-12)
+ * @param {string} day - Day (1-31)
+ * @returns {string} ISO date string or empty string if incomplete
+ */
+export function formatDateIso(year, month, day) {
+  if (!year || !month || !day) return "";
+
+  const y = year.padStart(4, "0");
+  const m = month.padStart(2, "0");
+  const d = day.padStart(2, "0");
+
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Validate date parts.
+ * @param {string} year - Year
+ * @param {string} month - Month
+ * @param {string} day - Day
+ * @returns {boolean} True if valid date
+ */
+export function isValidDate(year, month, day) {
+  if (!year || !month || !day) return false;
+
+  const y = parseInt(year, 10);
+  const m = parseInt(month, 10);
+  const d = parseInt(day, 10);
+
+  if (isNaN(y) || isNaN(m) || isNaN(d)) return false;
+  if (m < 1 || m > 12) return false;
+  if (d < 1 || d > 31) return false;
+
+  // Check if date is valid (handles month lengths and leap years)
+  const date = new Date(y, m - 1, d);
+  return (
+    date.getFullYear() === y &&
+    date.getMonth() === m - 1 &&
+    date.getDate() === d
+  );
+}
+
+// Default export with all utilities
+export default {
+  parseOptionsJson,
+  generateId,
+  computeSelectClassName,
+  computeInputClassName,
+  computeTextareaClassName,
+  computeAriaDescribedBy,
+  getFlagText,
+  decorateOptions,
+  decorateCheckboxOptions,
+  filterByParentValue,
+  createOmniUpdateEvent,
+  createChangeEvent,
+  createBlurEvent,
+  createFocusEvent,
+  parseDateParts,
+  formatDateIso,
+  isValidDate
+};

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnFormUtils/sfGpsDsCaOnFormUtils.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnFormUtils/sfGpsDsCaOnFormUtils.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Shared utility functions for Ontario DS Form components. Reduces code duplication between Comm and Omni versions.</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnLabels/sfGpsDsCaOnLabels.js
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnLabels/sfGpsDsCaOnLabels.js
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Centralized labels module for Ontario Design System components.
+ *
+ * This module imports all Custom Labels and exports them for use in components.
+ * Labels are automatically translated based on the user's language setting.
+ *
+ * ## Usage
+ *
+ * ```javascript
+ * import { LABELS } from 'c/sfGpsDsCaOnLabels';
+ *
+ * // In component
+ * get searchButtonLabel() {
+ *   return LABELS.Common.Search;
+ * }
+ * ```
+ *
+ * ## Adding New Labels
+ *
+ * 1. Add the label to CustomLabels.labels-meta.xml
+ * 2. Add the French translation to fr_CA.translation-meta.xml
+ * 3. Import the label in this file
+ * 4. Add to the appropriate LABELS category
+ *
+ * @module sfGpsDsCaOnLabels
+ */
+
+// ========================================
+// COMMON UI LABELS
+// ========================================
+import Common_Search from "@salesforce/label/c.sfGpsDsCaOn_Common_Search";
+import Common_Select from "@salesforce/label/c.sfGpsDsCaOn_Common_Select";
+import Common_Loading from "@salesforce/label/c.sfGpsDsCaOn_Common_Loading";
+import Common_Save from "@salesforce/label/c.sfGpsDsCaOn_Common_Save";
+import Common_Cancel from "@salesforce/label/c.sfGpsDsCaOn_Common_Cancel";
+import Common_Close from "@salesforce/label/c.sfGpsDsCaOn_Common_Close";
+import Common_Continue from "@salesforce/label/c.sfGpsDsCaOn_Common_Continue";
+import Common_Back from "@salesforce/label/c.sfGpsDsCaOn_Common_Back";
+import Common_Next from "@salesforce/label/c.sfGpsDsCaOn_Common_Next";
+import Common_Previous from "@salesforce/label/c.sfGpsDsCaOn_Common_Previous";
+import Common_Required from "@salesforce/label/c.sfGpsDsCaOn_Common_Required";
+import Common_Optional from "@salesforce/label/c.sfGpsDsCaOn_Common_Optional";
+import Common_Clear from "@salesforce/label/c.sfGpsDsCaOn_Common_Clear";
+import Common_Edit from "@salesforce/label/c.sfGpsDsCaOn_Common_Edit";
+import Common_Delete from "@salesforce/label/c.sfGpsDsCaOn_Common_Delete";
+import Common_Add from "@salesforce/label/c.sfGpsDsCaOn_Common_Add";
+import Common_Remove from "@salesforce/label/c.sfGpsDsCaOn_Common_Remove";
+import Common_ShowDetails from "@salesforce/label/c.sfGpsDsCaOn_Common_ShowDetails";
+import Common_HideDetails from "@salesforce/label/c.sfGpsDsCaOn_Common_HideDetails";
+import Common_ExpandAll from "@salesforce/label/c.sfGpsDsCaOn_Common_ExpandAll";
+import Common_CollapseAll from "@salesforce/label/c.sfGpsDsCaOn_Common_CollapseAll";
+import Common_BackToTop from "@salesforce/label/c.sfGpsDsCaOn_Common_BackToTop";
+import Common_SkipToContent from "@salesforce/label/c.sfGpsDsCaOn_Common_SkipToContent";
+import Common_SkipOptions from "@salesforce/label/c.sfGpsDsCaOn_Common_SkipOptions";
+
+// ========================================
+// SITE SELECTOR LABELS
+// ========================================
+import SiteSelector_Title from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_Title";
+import SiteSelector_ButtonLabel from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_ButtonLabel";
+import SiteSelector_SearchByParameters from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_SearchByParameters";
+import SiteSelector_SearchPlaceholder from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_SearchPlaceholder";
+import SiteSelector_ClearSearch from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_ClearSearch";
+import SiteSelector_SubmittedLocation from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_SubmittedLocation";
+import SiteSelector_SubmittedHint from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_SubmittedHint";
+import SiteSelector_LocationDetails from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_LocationDetails";
+import SiteSelector_SaveInstructions from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_SaveInstructions";
+import SiteSelector_SaveSiteAddress from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_SaveSiteAddress";
+import SiteSelector_TabSearch from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_TabSearch";
+import SiteSelector_TabSitePoint from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_TabSitePoint";
+import SiteSelector_TabLayers from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_TabLayers";
+import SiteSelector_Address from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_Address";
+import SiteSelector_Coordinates from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_Coordinates";
+import SiteSelector_LotConcession from "@salesforce/label/c.sfGpsDsCaOn_SiteSelector_LotConcession";
+
+// ========================================
+// DISCHARGE POINT LABELS
+// ========================================
+import DischargePoint_Title from "@salesforce/label/c.sfGpsDsCaOn_DischargePoint_Title";
+import DischargePoint_ButtonLabel from "@salesforce/label/c.sfGpsDsCaOn_DischargePoint_ButtonLabel";
+import DischargePoint_SearchMethod from "@salesforce/label/c.sfGpsDsCaOn_DischargePoint_SearchMethod";
+import DischargePoint_LatLong from "@salesforce/label/c.sfGpsDsCaOn_DischargePoint_LatLong";
+import DischargePoint_UTM from "@salesforce/label/c.sfGpsDsCaOn_DischargePoint_UTM";
+import DischargePoint_DecimalDegrees from "@salesforce/label/c.sfGpsDsCaOn_DischargePoint_DecimalDegrees";
+import DischargePoint_DMS from "@salesforce/label/c.sfGpsDsCaOn_DischargePoint_DMS";
+import DischargePoint_UTMConversionError from "@salesforce/label/c.sfGpsDsCaOn_DischargePoint_UTMConversionError";
+import DischargePoint_TabPinDrop from "@salesforce/label/c.sfGpsDsCaOn_DischargePoint_TabPinDrop";
+
+// ========================================
+// TASK LIST LABELS
+// ========================================
+import Task_NotStarted from "@salesforce/label/c.sfGpsDsCaOn_Task_NotStarted";
+import Task_InProgress from "@salesforce/label/c.sfGpsDsCaOn_Task_InProgress";
+import Task_Completed from "@salesforce/label/c.sfGpsDsCaOn_Task_Completed";
+import Task_CannotStart from "@salesforce/label/c.sfGpsDsCaOn_Task_CannotStart";
+import Task_Error from "@salesforce/label/c.sfGpsDsCaOn_Task_Error";
+
+// ========================================
+// ERROR MESSAGES - NETWORK
+// ========================================
+import Error_NetworkTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_NetworkTitle";
+import Error_NetworkMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_NetworkMessage";
+import Error_TimeoutTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_TimeoutTitle";
+import Error_TimeoutMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_TimeoutMessage";
+
+// ========================================
+// ERROR MESSAGES - LOCATION
+// ========================================
+import Error_LocationNotFoundTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_LocationNotFoundTitle";
+import Error_LocationNotFoundMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_LocationNotFoundMessage";
+import Error_LocationOutsideOntarioTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_LocationOutsideOntarioTitle";
+import Error_LocationOutsideOntarioMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_LocationOutsideOntarioMessage";
+import Error_SearchNoResultsTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_SearchNoResultsTitle";
+import Error_SearchNoResultsMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_SearchNoResultsMessage";
+
+// ========================================
+// ERROR MESSAGES - MAP
+// ========================================
+import Error_MapLoadTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_MapLoadTitle";
+import Error_MapLoadMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_MapLoadMessage";
+import Error_MapLayerTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_MapLayerTitle";
+import Error_MapLayerMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_MapLayerMessage";
+
+// ========================================
+// ERROR MESSAGES - SERVICE
+// ========================================
+import Error_ServiceUnavailableTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_ServiceUnavailableTitle";
+import Error_ServiceUnavailableMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_ServiceUnavailableMessage";
+import Error_EligibilityCheckTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_EligibilityCheckTitle";
+import Error_EligibilityCheckMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_EligibilityCheckMessage";
+import Error_DataLoadTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_DataLoadTitle";
+import Error_DataLoadMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_DataLoadMessage";
+import Error_SaveTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_SaveTitle";
+import Error_SaveMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_SaveMessage";
+
+// ========================================
+// ERROR MESSAGES - VALIDATION
+// ========================================
+import Error_RequiredFieldTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_RequiredFieldTitle";
+import Error_RequiredFieldMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_RequiredFieldMessage";
+import Error_InvalidFormatTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_InvalidFormatTitle";
+import Error_InvalidFormatMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_InvalidFormatMessage";
+import Error_InvalidEmailMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_InvalidEmailMessage";
+import Error_InvalidPhoneMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_InvalidPhoneMessage";
+import Error_InvalidPostalCodeMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_InvalidPostalCodeMessage";
+import Error_InvalidDateMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_InvalidDateMessage";
+
+// ========================================
+// ERROR MESSAGES - AUTH
+// ========================================
+import Error_SessionExpiredTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_SessionExpiredTitle";
+import Error_SessionExpiredMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_SessionExpiredMessage";
+import Error_AccessDeniedTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_AccessDeniedTitle";
+import Error_AccessDeniedMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_AccessDeniedMessage";
+
+// ========================================
+// ERROR MESSAGES - GENERIC
+// ========================================
+import Error_GenericTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_GenericTitle";
+import Error_GenericMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_GenericMessage";
+import Error_ConfigurationTitle from "@salesforce/label/c.sfGpsDsCaOn_Error_ConfigurationTitle";
+import Error_ConfigurationMessage from "@salesforce/label/c.sfGpsDsCaOn_Error_ConfigurationMessage";
+
+// ========================================
+// ERROR ACTIONS
+// ========================================
+import Error_ActionTryAgain from "@salesforce/label/c.sfGpsDsCaOn_Error_ActionTryAgain";
+import Error_ActionRefreshPage from "@salesforce/label/c.sfGpsDsCaOn_Error_ActionRefreshPage";
+import Error_ActionContactSupport from "@salesforce/label/c.sfGpsDsCaOn_Error_ActionContactSupport";
+import Error_ActionSignIn from "@salesforce/label/c.sfGpsDsCaOn_Error_ActionSignIn";
+
+// ========================================
+// ACCESSIBILITY
+// ========================================
+import A11y_AddressSelected from "@salesforce/label/c.sfGpsDsCaOn_A11y_AddressSelected";
+import A11y_LocationUpdated from "@salesforce/label/c.sfGpsDsCaOn_A11y_LocationUpdated";
+import A11y_SearchResults from "@salesforce/label/c.sfGpsDsCaOn_A11y_SearchResults";
+import A11y_NoResults from "@salesforce/label/c.sfGpsDsCaOn_A11y_NoResults";
+import A11y_LoadingComplete from "@salesforce/label/c.sfGpsDsCaOn_A11y_LoadingComplete";
+import A11y_FormError from "@salesforce/label/c.sfGpsDsCaOn_A11y_FormError";
+import A11y_StepOf from "@salesforce/label/c.sfGpsDsCaOn_A11y_StepOf";
+
+// ========================================
+// NAVIGATION / MENU LABELS
+// ========================================
+import Nav_Home from "@salesforce/label/c.sfGpsDsCaOn_Nav_Home";
+import Nav_About from "@salesforce/label/c.sfGpsDsCaOn_Nav_About";
+import Nav_Services from "@salesforce/label/c.sfGpsDsCaOn_Nav_Services";
+import Nav_Contact from "@salesforce/label/c.sfGpsDsCaOn_Nav_Contact";
+import Nav_Help from "@salesforce/label/c.sfGpsDsCaOn_Nav_Help";
+import Nav_FAQ from "@salesforce/label/c.sfGpsDsCaOn_Nav_FAQ";
+import Nav_Apply from "@salesforce/label/c.sfGpsDsCaOn_Nav_Apply";
+import Nav_MyAccount from "@salesforce/label/c.sfGpsDsCaOn_Nav_MyAccount";
+import Nav_SignIn from "@salesforce/label/c.sfGpsDsCaOn_Nav_SignIn";
+import Nav_SignOut from "@salesforce/label/c.sfGpsDsCaOn_Nav_SignOut";
+import Nav_Dashboard from "@salesforce/label/c.sfGpsDsCaOn_Nav_Dashboard";
+import Nav_Applications from "@salesforce/label/c.sfGpsDsCaOn_Nav_Applications";
+import Nav_Permits from "@salesforce/label/c.sfGpsDsCaOn_Nav_Permits";
+import Nav_Licenses from "@salesforce/label/c.sfGpsDsCaOn_Nav_Licenses";
+import Nav_Reports from "@salesforce/label/c.sfGpsDsCaOn_Nav_Reports";
+import Nav_Settings from "@salesforce/label/c.sfGpsDsCaOn_Nav_Settings";
+import Nav_Profile from "@salesforce/label/c.sfGpsDsCaOn_Nav_Profile";
+import Nav_Notifications from "@salesforce/label/c.sfGpsDsCaOn_Nav_Notifications";
+
+/**
+ * All labels organized by category.
+ * Labels are automatically translated based on user's language setting.
+ */
+export const LABELS = {
+  Common: {
+    Search: Common_Search,
+    Select: Common_Select,
+    Loading: Common_Loading,
+    Save: Common_Save,
+    Cancel: Common_Cancel,
+    Close: Common_Close,
+    Continue: Common_Continue,
+    Back: Common_Back,
+    Next: Common_Next,
+    Previous: Common_Previous,
+    Required: Common_Required,
+    Optional: Common_Optional,
+    Clear: Common_Clear,
+    Edit: Common_Edit,
+    Delete: Common_Delete,
+    Add: Common_Add,
+    Remove: Common_Remove,
+    ShowDetails: Common_ShowDetails,
+    HideDetails: Common_HideDetails,
+    ExpandAll: Common_ExpandAll,
+    CollapseAll: Common_CollapseAll,
+    BackToTop: Common_BackToTop,
+    SkipToContent: Common_SkipToContent,
+    SkipOptions: Common_SkipOptions
+  },
+
+  SiteSelector: {
+    Title: SiteSelector_Title,
+    ButtonLabel: SiteSelector_ButtonLabel,
+    SearchByParameters: SiteSelector_SearchByParameters,
+    SearchPlaceholder: SiteSelector_SearchPlaceholder,
+    ClearSearch: SiteSelector_ClearSearch,
+    SubmittedLocation: SiteSelector_SubmittedLocation,
+    SubmittedHint: SiteSelector_SubmittedHint,
+    LocationDetails: SiteSelector_LocationDetails,
+    SaveInstructions: SiteSelector_SaveInstructions,
+    SaveSiteAddress: SiteSelector_SaveSiteAddress,
+    TabSearch: SiteSelector_TabSearch,
+    TabSitePoint: SiteSelector_TabSitePoint,
+    TabLayers: SiteSelector_TabLayers,
+    Address: SiteSelector_Address,
+    Coordinates: SiteSelector_Coordinates,
+    LotConcession: SiteSelector_LotConcession
+  },
+
+  DischargePoint: {
+    Title: DischargePoint_Title,
+    ButtonLabel: DischargePoint_ButtonLabel,
+    SearchMethod: DischargePoint_SearchMethod,
+    LatLong: DischargePoint_LatLong,
+    UTM: DischargePoint_UTM,
+    DecimalDegrees: DischargePoint_DecimalDegrees,
+    DMS: DischargePoint_DMS,
+    UTMConversionError: DischargePoint_UTMConversionError,
+    TabPinDrop: DischargePoint_TabPinDrop
+  },
+
+  Task: {
+    NotStarted: Task_NotStarted,
+    InProgress: Task_InProgress,
+    Completed: Task_Completed,
+    CannotStart: Task_CannotStart,
+    Error: Task_Error
+  },
+
+  Error: {
+    NetworkTitle: Error_NetworkTitle,
+    NetworkMessage: Error_NetworkMessage,
+    TimeoutTitle: Error_TimeoutTitle,
+    TimeoutMessage: Error_TimeoutMessage,
+    LocationNotFoundTitle: Error_LocationNotFoundTitle,
+    LocationNotFoundMessage: Error_LocationNotFoundMessage,
+    LocationOutsideOntarioTitle: Error_LocationOutsideOntarioTitle,
+    LocationOutsideOntarioMessage: Error_LocationOutsideOntarioMessage,
+    SearchNoResultsTitle: Error_SearchNoResultsTitle,
+    SearchNoResultsMessage: Error_SearchNoResultsMessage,
+    MapLoadTitle: Error_MapLoadTitle,
+    MapLoadMessage: Error_MapLoadMessage,
+    MapLayerTitle: Error_MapLayerTitle,
+    MapLayerMessage: Error_MapLayerMessage,
+    ServiceUnavailableTitle: Error_ServiceUnavailableTitle,
+    ServiceUnavailableMessage: Error_ServiceUnavailableMessage,
+    EligibilityCheckTitle: Error_EligibilityCheckTitle,
+    EligibilityCheckMessage: Error_EligibilityCheckMessage,
+    DataLoadTitle: Error_DataLoadTitle,
+    DataLoadMessage: Error_DataLoadMessage,
+    SaveTitle: Error_SaveTitle,
+    SaveMessage: Error_SaveMessage,
+    RequiredFieldTitle: Error_RequiredFieldTitle,
+    RequiredFieldMessage: Error_RequiredFieldMessage,
+    InvalidFormatTitle: Error_InvalidFormatTitle,
+    InvalidFormatMessage: Error_InvalidFormatMessage,
+    InvalidEmailMessage: Error_InvalidEmailMessage,
+    InvalidPhoneMessage: Error_InvalidPhoneMessage,
+    InvalidPostalCodeMessage: Error_InvalidPostalCodeMessage,
+    InvalidDateMessage: Error_InvalidDateMessage,
+    SessionExpiredTitle: Error_SessionExpiredTitle,
+    SessionExpiredMessage: Error_SessionExpiredMessage,
+    AccessDeniedTitle: Error_AccessDeniedTitle,
+    AccessDeniedMessage: Error_AccessDeniedMessage,
+    GenericTitle: Error_GenericTitle,
+    GenericMessage: Error_GenericMessage,
+    ConfigurationTitle: Error_ConfigurationTitle,
+    ConfigurationMessage: Error_ConfigurationMessage,
+    ActionTryAgain: Error_ActionTryAgain,
+    ActionRefreshPage: Error_ActionRefreshPage,
+    ActionContactSupport: Error_ActionContactSupport,
+    ActionSignIn: Error_ActionSignIn
+  },
+
+  A11y: {
+    AddressSelected: A11y_AddressSelected,
+    LocationUpdated: A11y_LocationUpdated,
+    SearchResults: A11y_SearchResults,
+    NoResults: A11y_NoResults,
+    LoadingComplete: A11y_LoadingComplete,
+    FormError: A11y_FormError,
+    StepOf: A11y_StepOf
+  },
+
+  Nav: {
+    Home: Nav_Home,
+    About: Nav_About,
+    Services: Nav_Services,
+    Contact: Nav_Contact,
+    Help: Nav_Help,
+    FAQ: Nav_FAQ,
+    Apply: Nav_Apply,
+    MyAccount: Nav_MyAccount,
+    SignIn: Nav_SignIn,
+    SignOut: Nav_SignOut,
+    Dashboard: Nav_Dashboard,
+    Applications: Nav_Applications,
+    Permits: Nav_Permits,
+    Licenses: Nav_Licenses,
+    Reports: Nav_Reports,
+    Settings: Nav_Settings,
+    Profile: Nav_Profile,
+    Notifications: Nav_Notifications
+  }
+};
+
+/**
+ * Formats a label with placeholder replacements.
+ * Placeholders use {0}, {1}, etc. format.
+ *
+ * @param {string} label - The label with placeholders
+ * @param {...*} args - Values to replace placeholders
+ * @returns {string} Formatted string
+ *
+ * @example
+ * formatLabel(LABELS.A11y.StepOf, 2, 5); // "Step 2 of 5"
+ */
+export function formatLabel(label, ...args) {
+  if (!label) return "";
+  return label.replace(/\{(\d+)\}/g, (match, index) => {
+    const idx = parseInt(index, 10);
+    return idx < args.length ? String(args[idx]) : match;
+  });
+}
+
+/**
+ * Gets a task status label by status key.
+ *
+ * @param {string} status - Status key (e.g., "not-started", "in-progress")
+ * @returns {string} Translated status label
+ */
+export function getTaskStatusLabel(status) {
+  const statusMap = {
+    "not-started": LABELS.Task.NotStarted,
+    "in-progress": LABELS.Task.InProgress,
+    completed: LABELS.Task.Completed,
+    "cannot-start-yet": LABELS.Task.CannotStart,
+    optional: LABELS.Common.Optional,
+    error: LABELS.Task.Error
+  };
+  return statusMap[status] || status;
+}
+
+export default LABELS;

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnLabels/sfGpsDsCaOnLabels.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnLabels/sfGpsDsCaOnLabels.js-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>59.0</apiVersion>
+  <isExposed>false</isExposed>
+  <description
+  >Centralized labels module for Ontario Design System i18n support (English/French)</description>
+</LightningComponentBundle>

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnNaicsCodePickerOmni/sfGpsDsCaOnNaicsCodePickerOmni.css
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnNaicsCodePickerOmni/sfGpsDsCaOnNaicsCodePickerOmni.css
@@ -1,0 +1,128 @@
+/*
+ * Ontario Design System - NAICS Code Picker
+ * Custom styles for OmniStudio compatibility
+ */
+
+/* Import Ontario DS styles via static resource in the page */
+
+.sfgpsdscaon-naics-picker {
+  /* Ensure Ontario DS font is inherited */
+  font-family: "Open Sans", sans-serif;
+}
+
+.sfgpsdscaon-naics-picker .ontario-fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sfgpsdscaon-naics-picker .ontario-fieldset__legend {
+  padding: 0;
+  margin-bottom: 0.5rem;
+}
+
+.sfgpsdscaon-naics-picker .ontario-form-group {
+  margin-bottom: 1.5rem;
+}
+
+.sfgpsdscaon-naics-picker .ontario-label {
+  display: block;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  color: #1a1a1a;
+}
+
+.sfgpsdscaon-naics-picker .ontario-label__flag {
+  font-weight: 400;
+  font-style: normal;
+}
+
+.sfgpsdscaon-naics-picker .ontario-hint {
+  color: #666666;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+}
+
+.sfgpsdscaon-naics-picker .ontario-dropdown__container {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+  max-width: 48rem;
+}
+
+.sfgpsdscaon-naics-picker .ontario-dropdown {
+  width: 100%;
+  height: 48px;
+  padding: 0 48px 0 16px;
+  font-size: 1rem;
+  font-family: inherit;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+  background-color: #fff;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  cursor: pointer;
+}
+
+.sfgpsdscaon-naics-picker .ontario-dropdown:focus {
+  outline: 4px solid #009ade;
+  outline-offset: 2px;
+  border-color: #1a1a1a;
+}
+
+.sfgpsdscaon-naics-picker .ontario-dropdown:disabled {
+  background-color: #e0e0e0;
+  border-color: #666666;
+  color: #666666;
+  cursor: not-allowed;
+}
+
+.sfgpsdscaon-naics-picker .ontario-dropdown__icon {
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  pointer-events: none;
+  fill: #1a1a1a;
+}
+
+.sfgpsdscaon-naics-picker .ontario-dropdown:disabled + .ontario-dropdown__icon {
+  fill: #666666;
+}
+
+/* Error styling */
+.sfgpsdscaon-naics-picker .ontario-error-messaging {
+  display: flex;
+  align-items: flex-start;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  background-color: #fce4e4;
+  border-left: 4px solid #cd0000;
+}
+
+.sfgpsdscaon-naics-picker .ontario-error-messaging .ontario-icon {
+  width: 24px;
+  height: 24px;
+  fill: #cd0000;
+  flex-shrink: 0;
+  margin-right: 0.5rem;
+}
+
+.sfgpsdscaon-naics-picker .ontario-error-messaging__content {
+  color: #1a1a1a;
+  font-size: 1rem;
+}
+
+/* Selected value display */
+.sfgpsdscaon-naics-picker__selection {
+  margin-top: 1rem;
+  padding: 1rem;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+}

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnNaicsCodePickerOmni/sfGpsDsCaOnNaicsCodePickerOmni.html
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnNaicsCodePickerOmni/sfGpsDsCaOnNaicsCodePickerOmni.html
@@ -1,0 +1,198 @@
+<template>
+  <div class="sfgpsdscaon-naics-picker">
+    <fieldset class="ontario-fieldset">
+      <legend class="ontario-fieldset__legend">
+        <span class="ontario-label">{label}</span>
+        <template lwc:if={required}>
+          <span class="ontario-label__flag">(required)</span>
+        </template>
+        <template lwc:if={optional}>
+          <span class="ontario-label__flag">(optional)</span>
+        </template>
+      </legend>
+
+      <p lwc:if={helpText} class="ontario-hint">{helpText}</p>
+
+      <!-- Error message -->
+      <div
+        lwc:if={hasError}
+        class="ontario-error-messaging"
+        role="alert"
+        aria-live="assertive"
+      >
+        <svg
+          class="ontario-icon"
+          aria-hidden="true"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+          />
+        </svg>
+        <span class="ontario-error-messaging__content">{errorMessage}</span>
+      </div>
+
+      <!-- Sector Dropdown -->
+      <div class="ontario-form-group">
+        <label class="ontario-label" for="sector-select">{sectorLabel}</label>
+        <div class="ontario-dropdown__container">
+          <select
+            id="sector-select"
+            class="ontario-dropdown"
+            disabled={disabled}
+            onchange={handleSectorChange}
+          >
+            <option value="">Select</option>
+            <template for:each={sectorOptionsWithSelected} for:item="opt">
+              <option key={opt.value} value={opt.value} selected={opt.selected}>
+                {opt.label}
+              </option>
+            </template>
+          </select>
+          <svg
+            class="ontario-dropdown__icon"
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
+          </svg>
+        </div>
+      </div>
+
+      <!-- Sub Sector Dropdown -->
+      <div class="ontario-form-group">
+        <label class="ontario-label" for="subsector-select"
+          >{subSectorLabel}</label
+        >
+        <div class="ontario-dropdown__container">
+          <select
+            id="subsector-select"
+            class="ontario-dropdown"
+            disabled={isSubSectorDisabled}
+            onchange={handleSubSectorChange}
+          >
+            <option value="">Select</option>
+            <template for:each={subSectorOptionsWithSelected} for:item="opt">
+              <option key={opt.value} value={opt.value} selected={opt.selected}>
+                {opt.label}
+              </option>
+            </template>
+          </select>
+          <svg
+            class="ontario-dropdown__icon"
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
+          </svg>
+        </div>
+      </div>
+
+      <!-- Industry Group Dropdown -->
+      <div class="ontario-form-group">
+        <label class="ontario-label" for="industrygroup-select"
+          >{industryGroupLabel}</label
+        >
+        <div class="ontario-dropdown__container">
+          <select
+            id="industrygroup-select"
+            class="ontario-dropdown"
+            disabled={isIndustryGroupDisabled}
+            onchange={handleIndustryGroupChange}
+          >
+            <option value="">Select</option>
+            <template
+              for:each={industryGroupOptionsWithSelected}
+              for:item="opt"
+            >
+              <option key={opt.value} value={opt.value} selected={opt.selected}>
+                {opt.label}
+              </option>
+            </template>
+          </select>
+          <svg
+            class="ontario-dropdown__icon"
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
+          </svg>
+        </div>
+      </div>
+
+      <!-- Industry Dropdown -->
+      <div class="ontario-form-group">
+        <label class="ontario-label" for="industry-select"
+          >{industryLabel}</label
+        >
+        <div class="ontario-dropdown__container">
+          <select
+            id="industry-select"
+            class="ontario-dropdown"
+            disabled={isIndustryDisabled}
+            onchange={handleIndustryChange}
+          >
+            <option value="">Select</option>
+            <template for:each={industryOptionsWithSelected} for:item="opt">
+              <option key={opt.value} value={opt.value} selected={opt.selected}>
+                {opt.label}
+              </option>
+            </template>
+          </select>
+          <svg
+            class="ontario-dropdown__icon"
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
+          </svg>
+        </div>
+      </div>
+
+      <!-- National Industry Dropdown -->
+      <div class="ontario-form-group">
+        <label class="ontario-label" for="nationalindustry-select"
+          >{nationalIndustryLabel}</label
+        >
+        <div class="ontario-dropdown__container">
+          <select
+            id="nationalindustry-select"
+            class="ontario-dropdown"
+            disabled={isNationalIndustryDisabled}
+            onchange={handleNationalIndustryChange}
+          >
+            <option value="">Select</option>
+            <template
+              for:each={nationalIndustryOptionsWithSelected}
+              for:item="opt"
+            >
+              <option key={opt.value} value={opt.value} selected={opt.selected}>
+                {opt.label}
+              </option>
+            </template>
+          </select>
+          <svg
+            class="ontario-dropdown__icon"
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
+          </svg>
+        </div>
+      </div>
+
+      <!-- Selected value display -->
+      <div lwc:if={hasValue} class="sfgpsdscaon-naics-picker__selection">
+        <p class="ontario-hint">
+          <strong>Selected NAICS Code:</strong> {value}
+        </p>
+      </div>
+    </fieldset>
+  </div>
+</template>

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnNaicsCodePickerOmni/sfGpsDsCaOnNaicsCodePickerOmni.js
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnNaicsCodePickerOmni/sfGpsDsCaOnNaicsCodePickerOmni.js
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2026, Shannon Schupbach, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { LightningElement, api, track } from "lwc";
+import { OmniscriptBaseMixin } from "omnistudio/omniscriptBaseMixin";
+import {
+  parseOptionsJson,
+  decorateOptions,
+  filterByParentValue
+} from "c/sfGpsDsCaOnFormUtils";
+
+const DEBUG = false;
+const CLASS_NAME = "SfGpsDsCaOnNaicsCodePickerOmni";
+
+/**
+ * NAICS Code Picker for OmniStudio Custom LWC
+ * Uses OmniscriptBaseMixin for proper OmniScript data integration.
+ *
+ * OmniScript Integration:
+ * - Set fieldName property to specify where value is stored in omniJsonData
+ * - Uses omniUpdateDataJson() to update OmniScript data
+ * - Supports both single field (NAICS code only) and full object output
+ */
+export default class SfGpsDsCaOnNaicsCodePickerOmni extends OmniscriptBaseMixin(
+  LightningElement
+) {
+  /* ========================================
+   * PUBLIC @api PROPERTIES
+   * ======================================== */
+
+  @api label = "Select NAICS Code";
+  @api helpText = "";
+  @api required = false;
+  @api disabled = false;
+
+  @api optional = false;
+  @api errorMessage;
+
+  // OmniScript integration - field names for each level
+  /** Field name for storing the selected NAICS code (national industry) */
+  @api fieldName = "naicsCode";
+
+  /** Field name for Sector selection */
+  @api sectorFieldName = "";
+
+  /** Field name for Sub Sector selection */
+  @api subSectorFieldName = "";
+
+  /** Field name for Industry Group selection */
+  @api industryGroupFieldName = "";
+
+  /** Field name for Industry selection */
+  @api industryFieldName = "";
+
+  @api sectorLabel = "Sector";
+  @api subSectorLabel = "Sub sector";
+  @api industryGroupLabel = "Industry group";
+  @api industryLabel = "Industry";
+  @api nationalIndustryLabel = "National industry";
+
+  @api sectorOptionsJson;
+  @api subSectorOptionsJson;
+  @api industryGroupOptionsJson;
+  @api industryOptionsJson;
+  @api nationalIndustryOptionsJson;
+
+  /* ========================================
+   * PRIVATE STATE
+   * ======================================== */
+
+  @track _sector = "";
+  @track _subSector = "";
+  @track _industryGroup = "";
+  @track _industry = "";
+  @track _nationalIndustry = "";
+
+  _sectorOptions = [];
+  _subSectorOptions = [];
+  _industryGroupOptions = [];
+  _industryOptions = [];
+  _nationalIndustryOptions = [];
+
+  /* ========================================
+   * LIFECYCLE
+   * ======================================== */
+
+  connectedCallback() {
+    if (DEBUG) {
+      console.log(CLASS_NAME, "connectedCallback", {
+        label: this.label,
+        sectorOptionsJson: this.sectorOptionsJson?.substring(0, 50)
+      });
+    }
+
+    // Parse options using shared utility
+    this._sectorOptions = parseOptionsJson(this.sectorOptionsJson);
+    this._subSectorOptions = parseOptionsJson(this.subSectorOptionsJson);
+    this._industryGroupOptions = parseOptionsJson(
+      this.industryGroupOptionsJson
+    );
+    this._industryOptions = parseOptionsJson(this.industryOptionsJson);
+    this._nationalIndustryOptions = parseOptionsJson(
+      this.nationalIndustryOptionsJson
+    );
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "parsed options", {
+        sectors: this._sectorOptions.length,
+        subSectors: this._subSectorOptions.length
+      });
+    }
+  }
+
+  /* ========================================
+   * COMPUTED PROPERTIES
+   * ======================================== */
+
+  get sectorOptions() {
+    return this._sectorOptions;
+  }
+
+  get sectorOptionsWithSelected() {
+    return decorateOptions(this._sectorOptions, this._sector);
+  }
+
+  get subSectorOptions() {
+    return filterByParentValue(this._subSectorOptions, this._sector);
+  }
+
+  get subSectorOptionsWithSelected() {
+    return decorateOptions(this.subSectorOptions, this._subSector);
+  }
+
+  get industryGroupOptions() {
+    return filterByParentValue(this._industryGroupOptions, this._subSector);
+  }
+
+  get industryGroupOptionsWithSelected() {
+    return decorateOptions(this.industryGroupOptions, this._industryGroup);
+  }
+
+  get industryOptions() {
+    return filterByParentValue(this._industryOptions, this._industryGroup);
+  }
+
+  get industryOptionsWithSelected() {
+    return decorateOptions(this.industryOptions, this._industry);
+  }
+
+  get nationalIndustryOptions() {
+    return filterByParentValue(this._nationalIndustryOptions, this._industry);
+  }
+
+  get nationalIndustryOptionsWithSelected() {
+    return decorateOptions(
+      this.nationalIndustryOptions,
+      this._nationalIndustry
+    );
+  }
+
+  get isSubSectorDisabled() {
+    return this.disabled || !this._sector;
+  }
+
+  get isIndustryGroupDisabled() {
+    return this.disabled || !this._subSector;
+  }
+
+  get isIndustryDisabled() {
+    return this.disabled || !this._industryGroup;
+  }
+
+  get isNationalIndustryDisabled() {
+    return this.disabled || !this._industry;
+  }
+
+  get value() {
+    return this._nationalIndustry;
+  }
+
+  get hasValue() {
+    return Boolean(this._nationalIndustry);
+  }
+
+  get hasError() {
+    return Boolean(this.errorMessage);
+  }
+
+  /* ========================================
+   * PRIVATE METHODS (using shared utilities)
+   * ======================================== */
+
+  _dispatchChange() {
+    const detail = {
+      value: this._nationalIndustry,
+      sector: this._sector,
+      subSector: this._subSector,
+      industryGroup: this._industryGroup,
+      industry: this._industry
+    };
+
+    if (DEBUG) console.log(CLASS_NAME, "dispatchChange", detail);
+
+    // Dispatch standard change event
+    this.dispatchEvent(
+      new CustomEvent("change", {
+        detail,
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    // Dispatch OmniScript data update event
+    this._updateOmniScriptData(detail);
+  }
+
+  /**
+   * Updates OmniScript JSON data with the current selection.
+   * Uses omniUpdateDataJson() from OmniscriptBaseMixin for proper integration.
+   * Stores each level in its own field if field names are configured.
+   */
+  _updateOmniScriptData() {
+    // Build data object with all configured fields
+    const dataUpdate = {};
+
+    // Always store the main NAICS code (national industry) if fieldName is set
+    if (this.fieldName) {
+      dataUpdate[this.fieldName] = this._nationalIndustry || "";
+    }
+
+    // Store each level in its own field if configured
+    if (this.sectorFieldName) {
+      dataUpdate[this.sectorFieldName] = this._sector || "";
+    }
+
+    if (this.subSectorFieldName) {
+      dataUpdate[this.subSectorFieldName] = this._subSector || "";
+    }
+
+    if (this.industryGroupFieldName) {
+      dataUpdate[this.industryGroupFieldName] = this._industryGroup || "";
+    }
+
+    if (this.industryFieldName) {
+      dataUpdate[this.industryFieldName] = this._industry || "";
+    }
+
+    // Only update if we have at least one field configured
+    if (Object.keys(dataUpdate).length === 0) {
+      if (DEBUG)
+        console.log(
+          CLASS_NAME,
+          "_updateOmniScriptData: no field names configured, skipping"
+        );
+      return;
+    }
+
+    if (DEBUG) {
+      console.log(CLASS_NAME, "_updateOmniScriptData", dataUpdate);
+    }
+
+    // Use OmniscriptBaseMixin method to update OmniScript data
+    this.omniUpdateDataJson(dataUpdate);
+  }
+
+  /* ========================================
+   * EVENT HANDLERS
+   * ======================================== */
+
+  handleSectorChange(event) {
+    this._sector = event.target.value;
+    this._subSector = "";
+    this._industryGroup = "";
+    this._industry = "";
+    this._nationalIndustry = "";
+    this._dispatchChange();
+  }
+
+  handleSubSectorChange(event) {
+    this._subSector = event.target.value;
+    this._industryGroup = "";
+    this._industry = "";
+    this._nationalIndustry = "";
+    this._dispatchChange();
+  }
+
+  handleIndustryGroupChange(event) {
+    this._industryGroup = event.target.value;
+    this._industry = "";
+    this._nationalIndustry = "";
+    this._dispatchChange();
+  }
+
+  handleIndustryChange(event) {
+    this._industry = event.target.value;
+    this._nationalIndustry = "";
+    this._dispatchChange();
+  }
+
+  handleNationalIndustryChange(event) {
+    this._nationalIndustry = event.target.value;
+    this._dispatchChange();
+  }
+}

--- a/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnNaicsCodePickerOmni/sfGpsDsCaOnNaicsCodePickerOmni.js-meta.xml
+++ b/sfGpsDsCaOn/main/default/lwc/sfGpsDsCaOnNaicsCodePickerOmni/sfGpsDsCaOnNaicsCodePickerOmni.js-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <isExposed>true</isExposed>
+  <masterLabel>NAICS Code Picker (OmniStudio)</masterLabel>
+  <description
+  >NAICS Code Picker for OmniStudio Custom LWC elements. Uses SLDS styling.</description>
+  <targets>
+    <target>lightningCommunity__Page</target>
+    <target>lightningCommunity__Default</target>
+    <target>lightning__RecordPage</target>
+    <target>lightning__AppPage</target>
+  </targets>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary

This PR adds OmniStudio integration components for the Ontario Design System. This is a focused first PR containing only the core components.

### OmniScript Form Overrides (31 components)

Complete set of form element overrides styled with Ontario Design System:

- **Text inputs:** Text, Textarea, Email, Password, Telephone, URL
- **Numeric:** Number, Currency, Range
- **Date/Time:** Date, Time, DateTime
- **Selection:** Select, Multiselect, Radio, Checkbox, SelectableCards
- **Advanced:** Lookup, Typeahead, PlacesTypeahead
- **Layout:** Step, StepChart, Block, TextBlock, Messaging, Formula, Image, File, Disclosure
- **Custom:** SiteSelectorTool, DischargePointSelector

### OmniScript Custom LWCs

- `sfGpsDsCaOnAccordionOmni` - Collapsible accordion sections
- `sfGpsDsCaOnCalloutOmni` - Alert/callout messages
- `sfGpsDsCaOnCardOmni` - Card component
- `sfGpsDsCaOnFormFormReviewOmni` - Form review/summary page
- `sfGpsDsCaOnNaicsCodePickerOmni` - NAICS industry code selector

### Utility Components

- `sfGpsDsCaOnFormUtils` - Form validation and helper functions
- `sfGpsDsCaOnLabels` - Label management utilities

## Files Changed

**145 files** (down from 1089 in previous version)

## Future PRs

Additional PRs will follow for:
- GIS components (SiteSelectorTool, DischargePointSelector, CoordinateInput)
- New UI components (ActionCard, Modal, NotificationCard)
- Apex controllers
- Tests and documentation
- Build optimizations

## Test Plan

- [ ] Deploy to scratch org with OmniStudio installed
- [ ] Verify form overrides render with Ontario DS styling
- [ ] Test form validation in OmniScript flows
- [ ] Check Custom LWCs work in OmniScript FlexCards