### PR TITLE
Add missing Custom Labels and French translations

### DIFF
--- a/sfGpsDsCaOn/main/default/labels/CustomLabels.labels-meta.xml
+++ b/sfGpsDsCaOn/main/default/labels/CustomLabels.labels-meta.xml
@@ -1,0 +1,922 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+    <!-- 
+      Ontario Design System Custom Labels
+      Bilingual support for English (en_US) and French (fr_CA)
+      
+      Naming Convention: sfGpsDsCaOn_[Category]_[Name]
+      Categories:
+        - Common: Shared UI elements (buttons, labels)
+        - Error: Error messages
+        - SiteSelector: Site Selector Tool specific
+        - DischargePoint: Discharge Point Selector specific
+        - Task: Task List specific
+        - Form: Form-related labels
+        - A11y: Accessibility announcements
+    -->
+    
+    <!-- ========================================
+         COMMON UI LABELS
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Search</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Search button label</shortDescription>
+        <value>Search</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Select</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Select dropdown default</shortDescription>
+        <value>Select</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Loading</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Loading indicator</shortDescription>
+        <value>Loading</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Save</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Save button</shortDescription>
+        <value>Save</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Cancel</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Cancel button</shortDescription>
+        <value>Cancel</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Close</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Close button</shortDescription>
+        <value>Close</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Continue</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Continue button</shortDescription>
+        <value>Continue</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Back</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Back button</shortDescription>
+        <value>Back</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Next</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Next button</shortDescription>
+        <value>Next</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Previous</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Previous button</shortDescription>
+        <value>Previous</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Required</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Required field indicator</shortDescription>
+        <value>required</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Optional</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Optional field indicator</shortDescription>
+        <value>optional</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Clear</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Clear button</shortDescription>
+        <value>Clear</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Edit</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Edit button</shortDescription>
+        <value>Edit</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Delete</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Delete button</shortDescription>
+        <value>Delete</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Add</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Add button</shortDescription>
+        <value>Add</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_Remove</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Remove button</shortDescription>
+        <value>Remove</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_ShowDetails</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Show details toggle</shortDescription>
+        <value>Show Details</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_HideDetails</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Hide details toggle</shortDescription>
+        <value>Hide Details</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_ExpandAll</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Expand all accordion sections</shortDescription>
+        <value>Expand all</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_CollapseAll</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Collapse all accordion sections</shortDescription>
+        <value>Collapse all</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_BackToTop</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Back to top button</shortDescription>
+        <value>Back to top</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_SkipToContent</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Skip navigation link</shortDescription>
+        <value>Skip to main content</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Common_SkipOptions</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Skip past options link</shortDescription>
+        <value>Skip past options</value>
+    </labels>
+    
+    <!-- ========================================
+         SITE SELECTOR TOOL LABELS
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_SiteSelector_SearchByParameters</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Search parameter dropdown label</shortDescription>
+        <value>Search by other parameters</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_SiteSelector_ClearSearch</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Clear search button</shortDescription>
+        <value>Clear search</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_SiteSelector_SubmittedLocation</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Read-only mode title</shortDescription>
+        <value>Submitted Location</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_SiteSelector_SubmittedHint</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Read-only mode hint</shortDescription>
+        <value
+    >This location was captured during the application submission.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_SiteSelector_LocationDetails</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Location details heading</shortDescription>
+        <value>Site location details</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_SiteSelector_SaveInstructions</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Save instructions text</shortDescription>
+        <value
+    >Once you have finalized the site location, select "Save site address".</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_SiteSelector_SaveSiteAddress</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Save site address button</shortDescription>
+        <value>Save site address</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_SiteSelector_TabSearch</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Search tab label</shortDescription>
+        <value>Search</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_SiteSelector_TabSitePoint</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Site point tab label</shortDescription>
+        <value>Site point</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_SiteSelector_TabLayers</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Map layers tab label</shortDescription>
+        <value>Map layers</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_SiteSelector_Address</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Address search option</shortDescription>
+        <value>Address</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_SiteSelector_Coordinates</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Coordinates search option</shortDescription>
+        <value>Coordinates</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_SiteSelector_LotConcession</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Lot/Concession search option</shortDescription>
+        <value>Lot/Concession</value>
+    </labels>
+    
+    <!-- ========================================
+         DISCHARGE POINT SELECTOR LABELS
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_DischargePoint_SearchMethod</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Search method label</shortDescription>
+        <value>Search method</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_DischargePoint_LatLong</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Lat/Long option</shortDescription>
+        <value>Lat/Long</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_DischargePoint_UTM</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>UTM option</shortDescription>
+        <value>UTM</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_DischargePoint_DecimalDegrees</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Decimal degrees format</shortDescription>
+        <value>Decimal Degrees</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_DischargePoint_DMS</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Degrees/Minutes/Seconds format</shortDescription>
+        <value>Degrees/Minutes/Seconds</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_DischargePoint_UTMConversionError</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>UTM conversion error message</shortDescription>
+        <value
+    >UTM conversion requires server processing. Please use the map or enter decimal coordinates.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_DischargePoint_TabPinDrop</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Pin drop tab label</shortDescription>
+        <value>Pin drop</value>
+    </labels>
+    
+    <!-- ========================================
+         TASK LIST LABELS
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_Task_NotStarted</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Not started status</shortDescription>
+        <value>Not started</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Task_InProgress</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>In progress status</shortDescription>
+        <value>In progress</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Task_Completed</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Completed status</shortDescription>
+        <value>Completed</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Task_CannotStart</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Cannot start yet status</shortDescription>
+        <value>Cannot yet start</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Task_Error</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Error status</shortDescription>
+        <value>Error</value>
+    </labels>
+    
+    <!-- ========================================
+         ERROR MESSAGES - NETWORK/CONNECTION
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_NetworkTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Network error title</shortDescription>
+        <value>Connection problem</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_NetworkMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Network error message</shortDescription>
+        <value
+    >We couldn't connect to the server. Please check your internet connection and try again.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_TimeoutTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Timeout error title</shortDescription>
+        <value>Request timed out</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_TimeoutMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Timeout error message</shortDescription>
+        <value
+    >The request is taking longer than expected. Please try again in a few moments.</value>
+    </labels>
+    
+    <!-- ========================================
+         ERROR MESSAGES - LOCATION/SEARCH
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_LocationNotFoundTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Location not found title</shortDescription>
+        <value>Location not found</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_LocationNotFoundMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Location not found message</shortDescription>
+        <value
+    >We couldn't find that address or location. Please check the spelling or try a different search.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_LocationOutsideOntarioTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Location outside Ontario title</shortDescription>
+        <value>Location outside Ontario</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_LocationOutsideOntarioMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Location outside Ontario message</shortDescription>
+        <value
+    >The selected location is outside of Ontario. This service is only available for Ontario locations.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_SearchNoResultsTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Search no results title</shortDescription>
+        <value>No results found</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_SearchNoResultsMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Search no results message</shortDescription>
+        <value
+    >We couldn't find any results for your search. Try using different keywords or check the spelling.</value>
+    </labels>
+    
+    <!-- ========================================
+         ERROR MESSAGES - MAP
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_MapLoadTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Map load error title</shortDescription>
+        <value>Map unavailable</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_MapLoadMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Map load error message</shortDescription>
+        <value
+    >We're having trouble loading the map. You can still enter your location using the search field.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_MapLayerTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Map layer error title</shortDescription>
+        <value>Map layer unavailable</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_MapLayerMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Map layer error message</shortDescription>
+        <value
+    >Some map information couldn't be loaded. The basic map is still available.</value>
+    </labels>
+    
+    <!-- ========================================
+         ERROR MESSAGES - SERVICE/API
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_ServiceUnavailableTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Service unavailable title</shortDescription>
+        <value>Service temporarily unavailable</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_ServiceUnavailableMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Service unavailable message</shortDescription>
+        <value
+    >This service is temporarily unavailable. Please try again later or contact support if the problem continues.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_EligibilityCheckTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Eligibility check error title</shortDescription>
+        <value>Unable to check eligibility</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_EligibilityCheckMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Eligibility check error message</shortDescription>
+        <value
+    >We couldn't complete the eligibility check at this time. Please try again or contact support for assistance.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_DataLoadTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Data load error title</shortDescription>
+        <value>Unable to load data</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_DataLoadMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Data load error message</shortDescription>
+        <value
+    >We couldn't load the required information. Please refresh the page and try again.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_SaveTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Save error title</shortDescription>
+        <value>Unable to save</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_SaveMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Save error message</shortDescription>
+        <value
+    >We couldn't save your information. Please check your connection and try again.</value>
+    </labels>
+    
+    <!-- ========================================
+         ERROR MESSAGES - VALIDATION
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_RequiredFieldTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Required field error title</shortDescription>
+        <value>Required information missing</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_RequiredFieldMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Required field error message</shortDescription>
+        <value>Please provide the required information to continue.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_InvalidFormatTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Invalid format error title</shortDescription>
+        <value>Invalid format</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_InvalidFormatMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Invalid format error message</shortDescription>
+        <value
+    >The information you entered isn't in the right format. Please check and try again.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_InvalidEmailMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Invalid email error message</shortDescription>
+        <value
+    >Please enter a valid email address (e.g., name@example.com).</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_InvalidPhoneMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Invalid phone error message</shortDescription>
+        <value>Please enter a valid phone number (e.g., 416-555-1234).</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_InvalidPostalCodeMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Invalid postal code error message</shortDescription>
+        <value
+    >Please enter a valid Canadian postal code (e.g., M5V 3A8).</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_InvalidDateMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Invalid date error message</shortDescription>
+        <value>Please enter a valid date in the format DD/MM/YYYY.</value>
+    </labels>
+    
+    <!-- ========================================
+         ERROR MESSAGES - AUTH/SESSION
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_SessionExpiredTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Session expired title</shortDescription>
+        <value>Session expired</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_SessionExpiredMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Session expired message</shortDescription>
+        <value
+    >Your session has expired for security reasons. Please sign in again to continue.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_AccessDeniedTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Access denied title</shortDescription>
+        <value>Access denied</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_AccessDeniedMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Access denied message</shortDescription>
+        <value
+    >You don't have permission to access this feature. Please contact your administrator if you believe this is an error.</value>
+    </labels>
+    
+    <!-- ========================================
+         ERROR MESSAGES - GENERIC
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_GenericTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Generic error title</shortDescription>
+        <value>Something went wrong</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_GenericMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Generic error message</shortDescription>
+        <value
+    >We encountered an unexpected problem. Please try again or contact support if the issue continues.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_ConfigurationTitle</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Configuration error title</shortDescription>
+        <value>Configuration issue</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_ConfigurationMessage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Configuration error message</shortDescription>
+        <value
+    >There's a configuration issue with this application. Please contact support for assistance.</value>
+    </labels>
+    
+    <!-- ========================================
+         ERROR ACTIONS
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_ActionTryAgain</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Try again action</shortDescription>
+        <value>Try again</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_ActionRefreshPage</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Refresh page action</shortDescription>
+        <value>Refresh page</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_ActionContactSupport</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Contact support action</shortDescription>
+        <value>Contact support</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Error_ActionSignIn</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Sign in action</shortDescription>
+        <value>Sign in</value>
+    </labels>
+    
+    <!-- ========================================
+         ACCESSIBILITY ANNOUNCEMENTS
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_A11y_AddressSelected</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Address selected announcement</shortDescription>
+        <value>Address selected: {0}</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_A11y_LocationUpdated</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Location updated announcement</shortDescription>
+        <value>Location updated</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_A11y_SearchResults</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Search results announcement</shortDescription>
+        <value>{0} results found</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_A11y_NoResults</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>No results announcement</shortDescription>
+        <value>No results found</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_A11y_LoadingComplete</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Loading complete announcement</shortDescription>
+        <value>Loading complete</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_A11y_FormError</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Form error announcement</shortDescription>
+        <value
+    >There is an error in the form. Please check the highlighted fields.</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_A11y_StepOf</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Step indicator format</shortDescription>
+        <value>Step {0} of {1}</value>
+    </labels>
+    
+    <!-- ========================================
+         NAVIGATION / MENU LABELS
+         ======================================== -->
+    
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_Home</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Home menu item</shortDescription>
+        <value>Home</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_About</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>About menu item</shortDescription>
+        <value>About</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_Services</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Services menu item</shortDescription>
+        <value>Services</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_Contact</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Contact menu item</shortDescription>
+        <value>Contact</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_Help</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Help menu item</shortDescription>
+        <value>Help</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_FAQ</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>FAQ menu item</shortDescription>
+        <value>Frequently Asked Questions</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_Apply</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Apply menu item</shortDescription>
+        <value>Apply</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_MyAccount</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>My Account menu item</shortDescription>
+        <value>My Account</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_SignIn</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Sign In menu item</shortDescription>
+        <value>Sign In</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_SignOut</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Sign Out menu item</shortDescription>
+        <value>Sign Out</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_Dashboard</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Dashboard menu item</shortDescription>
+        <value>Dashboard</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_Applications</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Applications menu item</shortDescription>
+        <value>Applications</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_Permits</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Permits menu item</shortDescription>
+        <value>Permits</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_Licenses</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Licenses menu item</shortDescription>
+        <value>Licenses</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_Reports</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Reports menu item</shortDescription>
+        <value>Reports</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_Settings</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Settings menu item</shortDescription>
+        <value>Settings</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_Profile</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Profile menu item</shortDescription>
+        <value>Profile</value>
+    </labels>
+    <labels>
+        <fullName>sfGpsDsCaOn_Nav_Notifications</fullName>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Notifications menu item</shortDescription>
+        <value>Notifications</value>
+    </labels>
+    
+</CustomLabels>

--- a/sfGpsDsCaOn/main/default/translations/fr_CA.translation-meta.xml
+++ b/sfGpsDsCaOn/main/default/translations/fr_CA.translation-meta.xml
@@ -1,0 +1,519 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Translations xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customLabels>
+        <!-- COMMON UI LABELS -->
+        <label>sfGpsDsCaOn_Common_Search</label>
+        <translation>Rechercher</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Select</label>
+        <translation>Sélectionner</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Loading</label>
+        <translation>Chargement</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Save</label>
+        <translation>Enregistrer</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Cancel</label>
+        <translation>Annuler</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Close</label>
+        <translation>Fermer</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Continue</label>
+        <translation>Continuer</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Back</label>
+        <translation>Retour</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Next</label>
+        <translation>Suivant</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Previous</label>
+        <translation>Précédent</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Required</label>
+        <translation>obligatoire</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Optional</label>
+        <translation>facultatif</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Clear</label>
+        <translation>Effacer</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Edit</label>
+        <translation>Modifier</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Delete</label>
+        <translation>Supprimer</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Add</label>
+        <translation>Ajouter</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_Remove</label>
+        <translation>Retirer</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_ShowDetails</label>
+        <translation>Afficher les détails</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_HideDetails</label>
+        <translation>Masquer les détails</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_ExpandAll</label>
+        <translation>Tout développer</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_CollapseAll</label>
+        <translation>Tout réduire</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_BackToTop</label>
+        <translation>Retour en haut</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_SkipToContent</label>
+        <translation>Passer au contenu principal</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Common_SkipOptions</label>
+        <translation>Passer les options</translation>
+    </customLabels>
+    
+    <!-- SITE SELECTOR TOOL -->
+    <customLabels>
+        <label>sfGpsDsCaOn_SiteSelector_SearchByParameters</label>
+        <translation>Rechercher par autres paramètres</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_SiteSelector_ClearSearch</label>
+        <translation>Effacer la recherche</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_SiteSelector_SubmittedLocation</label>
+        <translation>Emplacement soumis</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_SiteSelector_SubmittedHint</label>
+        <translation
+    >Cet emplacement a été capturé lors de la soumission de la demande.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_SiteSelector_LocationDetails</label>
+        <translation>Détails de l'emplacement du site</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_SiteSelector_SaveInstructions</label>
+        <translation
+    >Une fois que vous avez finalisé l'emplacement du site, sélectionnez « Enregistrer l'adresse du site ».</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_SiteSelector_SaveSiteAddress</label>
+        <translation>Enregistrer l'adresse du site</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_SiteSelector_TabSearch</label>
+        <translation>Rechercher</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_SiteSelector_TabSitePoint</label>
+        <translation>Point du site</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_SiteSelector_TabLayers</label>
+        <translation>Couches de carte</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_SiteSelector_Address</label>
+        <translation>Adresse</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_SiteSelector_Coordinates</label>
+        <translation>Coordonnées</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_SiteSelector_LotConcession</label>
+        <translation>Lot/Concession</translation>
+    </customLabels>
+    
+    <!-- DISCHARGE POINT SELECTOR -->
+    <customLabels>
+        <label>sfGpsDsCaOn_DischargePoint_SearchMethod</label>
+        <translation>Méthode de recherche</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_DischargePoint_LatLong</label>
+        <translation>Lat/Long</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_DischargePoint_UTM</label>
+        <translation>UTM</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_DischargePoint_DecimalDegrees</label>
+        <translation>Degrés décimaux</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_DischargePoint_DMS</label>
+        <translation>Degrés/Minutes/Secondes</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_DischargePoint_UTMConversionError</label>
+        <translation
+    >La conversion UTM nécessite un traitement serveur. Veuillez utiliser la carte ou entrer des coordonnées décimales.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_DischargePoint_TabPinDrop</label>
+        <translation>Placer un repère</translation>
+    </customLabels>
+    
+    <!-- TASK LIST -->
+    <customLabels>
+        <label>sfGpsDsCaOn_Task_NotStarted</label>
+        <translation>Non commencé</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Task_InProgress</label>
+        <translation>En cours</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Task_Completed</label>
+        <translation>Terminé</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Task_CannotStart</label>
+        <translation>Impossible de commencer</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Task_Error</label>
+        <translation>Erreur</translation>
+    </customLabels>
+    
+    <!-- ERROR MESSAGES - NETWORK/CONNECTION -->
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_NetworkTitle</label>
+        <translation>Problème de connexion</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_NetworkMessage</label>
+        <translation
+    >Nous n'avons pas pu nous connecter au serveur. Veuillez vérifier votre connexion Internet et réessayer.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_TimeoutTitle</label>
+        <translation>Délai d'attente dépassé</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_TimeoutMessage</label>
+        <translation
+    >La demande prend plus de temps que prévu. Veuillez réessayer dans quelques instants.</translation>
+    </customLabels>
+    
+    <!-- ERROR MESSAGES - LOCATION/SEARCH -->
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_LocationNotFoundTitle</label>
+        <translation>Emplacement introuvable</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_LocationNotFoundMessage</label>
+        <translation
+    >Nous n'avons pas pu trouver cette adresse ou cet emplacement. Veuillez vérifier l'orthographe ou essayer une recherche différente.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_LocationOutsideOntarioTitle</label>
+        <translation>Emplacement hors de l'Ontario</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_LocationOutsideOntarioMessage</label>
+        <translation
+    >L'emplacement sélectionné est situé à l'extérieur de l'Ontario. Ce service n'est disponible que pour les emplacements en Ontario.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_SearchNoResultsTitle</label>
+        <translation>Aucun résultat trouvé</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_SearchNoResultsMessage</label>
+        <translation
+    >Nous n'avons trouvé aucun résultat pour votre recherche. Essayez d'utiliser des mots-clés différents ou vérifiez l'orthographe.</translation>
+    </customLabels>
+    
+    <!-- ERROR MESSAGES - MAP -->
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_MapLoadTitle</label>
+        <translation>Carte non disponible</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_MapLoadMessage</label>
+        <translation
+    >Nous avons des difficultés à charger la carte. Vous pouvez toujours entrer votre emplacement en utilisant le champ de recherche.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_MapLayerTitle</label>
+        <translation>Couche de carte non disponible</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_MapLayerMessage</label>
+        <translation
+    >Certaines informations de la carte n'ont pas pu être chargées. La carte de base est toujours disponible.</translation>
+    </customLabels>
+    
+    <!-- ERROR MESSAGES - SERVICE/API -->
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_ServiceUnavailableTitle</label>
+        <translation>Service temporairement indisponible</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_ServiceUnavailableMessage</label>
+        <translation
+    >Ce service est temporairement indisponible. Veuillez réessayer plus tard ou contacter le soutien technique si le problème persiste.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_EligibilityCheckTitle</label>
+        <translation>Impossible de vérifier l'admissibilité</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_EligibilityCheckMessage</label>
+        <translation
+    >Nous n'avons pas pu effectuer la vérification d'admissibilité pour le moment. Veuillez réessayer ou contacter le soutien technique pour obtenir de l'aide.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_DataLoadTitle</label>
+        <translation>Impossible de charger les données</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_DataLoadMessage</label>
+        <translation
+    >Nous n'avons pas pu charger les informations requises. Veuillez actualiser la page et réessayer.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_SaveTitle</label>
+        <translation>Impossible d'enregistrer</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_SaveMessage</label>
+        <translation
+    >Nous n'avons pas pu enregistrer vos informations. Veuillez vérifier votre connexion et réessayer.</translation>
+    </customLabels>
+    
+    <!-- ERROR MESSAGES - VALIDATION -->
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_RequiredFieldTitle</label>
+        <translation>Informations requises manquantes</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_RequiredFieldMessage</label>
+        <translation
+    >Veuillez fournir les informations requises pour continuer.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_InvalidFormatTitle</label>
+        <translation>Format invalide</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_InvalidFormatMessage</label>
+        <translation
+    >Les informations que vous avez entrées ne sont pas dans le bon format. Veuillez vérifier et réessayer.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_InvalidEmailMessage</label>
+        <translation
+    >Veuillez entrer une adresse courriel valide (ex. : nom@exemple.com).</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_InvalidPhoneMessage</label>
+        <translation
+    >Veuillez entrer un numéro de téléphone valide (ex. : 416-555-1234).</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_InvalidPostalCodeMessage</label>
+        <translation
+    >Veuillez entrer un code postal canadien valide (ex. : M5V 3A8).</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_InvalidDateMessage</label>
+        <translation
+    >Veuillez entrer une date valide au format JJ/MM/AAAA.</translation>
+    </customLabels>
+    
+    <!-- ERROR MESSAGES - AUTH/SESSION -->
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_SessionExpiredTitle</label>
+        <translation>Session expirée</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_SessionExpiredMessage</label>
+        <translation
+    >Votre session a expiré pour des raisons de sécurité. Veuillez vous reconnecter pour continuer.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_AccessDeniedTitle</label>
+        <translation>Accès refusé</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_AccessDeniedMessage</label>
+        <translation
+    >Vous n'avez pas la permission d'accéder à cette fonctionnalité. Veuillez contacter votre administrateur si vous pensez qu'il s'agit d'une erreur.</translation>
+    </customLabels>
+    
+    <!-- ERROR MESSAGES - GENERIC -->
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_GenericTitle</label>
+        <translation>Une erreur s'est produite</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_GenericMessage</label>
+        <translation
+    >Nous avons rencontré un problème inattendu. Veuillez réessayer ou contacter le soutien technique si le problème persiste.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_ConfigurationTitle</label>
+        <translation>Problème de configuration</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_ConfigurationMessage</label>
+        <translation
+    >Il y a un problème de configuration avec cette application. Veuillez contacter le soutien technique pour obtenir de l'aide.</translation>
+    </customLabels>
+    
+    <!-- ERROR ACTIONS -->
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_ActionTryAgain</label>
+        <translation>Réessayer</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_ActionRefreshPage</label>
+        <translation>Actualiser la page</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_ActionContactSupport</label>
+        <translation>Contacter le soutien technique</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Error_ActionSignIn</label>
+        <translation>Se connecter</translation>
+    </customLabels>
+    
+    <!-- ACCESSIBILITY ANNOUNCEMENTS -->
+    <customLabels>
+        <label>sfGpsDsCaOn_A11y_AddressSelected</label>
+        <translation>Adresse sélectionnée : {0}</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_A11y_LocationUpdated</label>
+        <translation>Emplacement mis à jour</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_A11y_SearchResults</label>
+        <translation>{0} résultats trouvés</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_A11y_NoResults</label>
+        <translation>Aucun résultat trouvé</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_A11y_LoadingComplete</label>
+        <translation>Chargement terminé</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_A11y_FormError</label>
+        <translation
+    >Il y a une erreur dans le formulaire. Veuillez vérifier les champs en surbrillance.</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_A11y_StepOf</label>
+        <translation>Étape {0} de {1}</translation>
+    </customLabels>
+    
+    <!-- NAVIGATION / MENU LABELS -->
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_Home</label>
+        <translation>Accueil</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_About</label>
+        <translation>À propos</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_Services</label>
+        <translation>Services</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_Contact</label>
+        <translation>Contact</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_Help</label>
+        <translation>Aide</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_FAQ</label>
+        <translation>Foire aux questions</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_Apply</label>
+        <translation>Soumettre une demande</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_MyAccount</label>
+        <translation>Mon compte</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_SignIn</label>
+        <translation>Connexion</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_SignOut</label>
+        <translation>Déconnexion</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_Dashboard</label>
+        <translation>Tableau de bord</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_Applications</label>
+        <translation>Demandes</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_Permits</label>
+        <translation>Permis</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_Licenses</label>
+        <translation>Licences</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_Reports</label>
+        <translation>Rapports</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_Settings</label>
+        <translation>Paramètres</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_Profile</label>
+        <translation>Profil</translation>
+    </customLabels>
+    <customLabels>
+        <label>sfGpsDsCaOn_Nav_Notifications</label>
+        <translation>Notifications</translation>
+    </customLabels>
+</Translations>


### PR DESCRIPTION
## Summary
- Add CustomLabels.labels-meta.xml with all label definitions required by CA Ontario components
- Add fr_CA.translation-meta.xml with French Canadian translations

This is a focused PR that adds just the essential metadata required for proper deployment. Component fixes and refactoring will be addressed in a separate PR.

## Test plan
- [ ] Deploy to a scratch org and verify no label reference errors
- [ ] Verify French translations load correctly when language is set to fr_CA